### PR TITLE
[runtests.py] Added indentation

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -12,4 +12,4 @@ if __name__ == "__main__":
     args = sys.argv
     args.insert(1, "test")
     args.insert(2, "openwisp_radius")
-execute_from_command_line(args)
+    execute_from_command_line(args)


### PR DESCRIPTION
I have added tabulation before [this line](https://github.com/openwisp/openwisp-radius/blob/master/runtests.py#L15), because in the previous version `execute_from_command_line(args)` line wasn't in if statement.