### PR TITLE
[settings] Enable CORS in django rest framework for cross-domain ajax requests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ responses
 freezegun
 openwisp-utils[qa]>=0.2.1
 djangorestframework-jwt
+django-cors-headers>=2.5.2

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -172,3 +172,16 @@ REST_AUTH_SERIALIZERS = {
 #     # use the uuid because the slug can change
 #     # 'dabbd57a-11ca-4277-8dbb-ad21057b5ecd': 'https://organization.com/{organization}/password/reset/{uid}/{token}',
 # }
+
+try:
+    import corsheaders
+
+    INSTALLED_APPS[:0] = ['corsheaders']
+
+    MIDDLEWARE[:0] = ['corsheaders.middleware.CorsMiddleware', 'django.middleware.common.CommonMiddleware']
+
+    # WARNING: for development only!
+    CORS_ORIGIN_ALLOW_ALL = True
+
+except ImportError:
+    pass


### PR DESCRIPTION
closes #46