### PR TITLE
[Travis] Fixed Warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 cache: pip
 
 python:


### PR DESCRIPTION
fixed this warning
[warn] on root: deprecated key: "sudo" (The key `sudo` has no effect anymore.)