### PR TITLE
[Travis] Fixed Warning(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 cache: pip
 
 python:


### PR DESCRIPTION
Fixed this Warning.

[warn] on root: deprecated key: "sudo" (The key `sudo` has no effect anymore)
Fixes #64 