### PR TITLE
[bug] Radius token for initial default org not created #71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# vscode project settings
+.vscode/
+
 # mkdocs documentation
 /site
 

--- a/openwisp_radius/migrations/__init__.py
+++ b/openwisp_radius/migrations/__init__.py
@@ -18,6 +18,8 @@ def add_default_organization(apps, schema_editor):
         for record in Model.objects.all().iterator():
             record.organization_id = settings._OPENWISP_DEFAULT_ORG_UUID
             record.save()
+    OrganizationRadiusSettings = apps.get_model('openwisp_radius', 'organizationradiussettings')
+    OrganizationRadiusSettings.objects.create(organization_id=settings._OPENWISP_DEFAULT_ORG_UUID)
 
 
 def add_default_groups(apps, schema_editor):

--- a/openwisp_radius/tests/mixins.py
+++ b/openwisp_radius/tests/mixins.py
@@ -5,8 +5,6 @@ from django_freeradius.tests import PostParamsMixin as BasePostParamsMixin
 
 from openwisp_users.models import Organization
 
-from ..models import OrganizationRadiusSettings
-
 
 class CreateRadiusObjectsMixin(BaseCreateRadiusObjectsMixin):
     def _create_org(self, **kwargs):
@@ -58,8 +56,7 @@ class ApiTokenMixin(BasePostParamsMixin):
     def setUp(self):
         super().setUp()
         org = self.default_org
-        rad = OrganizationRadiusSettings.objects.create(token='asdfghjklqwerty',
-                                                        organization=org)
+        rad = self.default_org.radius_settings
         self.auth_header = 'Bearer {0} {1}'.format(org.pk, rad.token)
         self.token_querystring = '?token={0}&uuid={1}'.format(rad.token, str(org.pk))
 

--- a/openwisp_radius/tests/tests.py
+++ b/openwisp_radius/tests/tests.py
@@ -618,7 +618,7 @@ class TestOgranizationRadiusSettings(ApiTokenMixin, BaseTestCase):
     user_model = User
 
     def setUp(self):
-        self.org = self._create_org()
+        self.org = self._create_org(name='test', slug='test')
 
     def test_string_representation(self):
         rad = OrganizationRadiusSettings.objects.create(organization=self.org)
@@ -674,6 +674,11 @@ class TestOgranizationRadiusSettings(ApiTokenMixin, BaseTestCase):
         r = self.client.post(post_url, {'username': 'molly', 'password': 'barbar'})
         self.assertEqual(r.status_code, 200)
         cache.clear()
+
+    def test_default_organisation_radius_settings(self):
+        org = Organization.objects.get(slug='default')
+        self.assertTrue(hasattr(org, 'radius_settings'))
+        self.assertIsInstance(org.radius_settings, OrganizationRadiusSettings)
 
 
 class TestRadiusToken(BaseTestRadiusToken, BaseTestCase):


### PR DESCRIPTION
Auto create OrganizationRadiusSettings object for the default organizaiton.
Fixes #71