### PR TITLE
[api] Fixed broken cache check in TokenAuthentication

### DIFF
--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -73,15 +73,16 @@ class TokenAuthentication(BaseAuthentication):
         uuid, token = self.get_uuid_token(request)
         if not uuid or not token:
             raise AuthenticationFailed(_TOKEN_AUTH_FAILED)
-        # check cache too
-        if not cache.get('uuid'):
+        # check cache first
+        cached_token = cache.get(uuid)
+        if not cached_token:
             try:
                 opts = dict(organization_id=uuid, token=token)
                 instance = OrganizationRadiusSettings.objects.get(**opts)
                 cache.set(uuid, instance.token)
             except OrganizationRadiusSettings.DoesNotExist:
                 raise AuthenticationFailed(_TOKEN_AUTH_FAILED)
-        elif cache.get(uuid) != token:
+        elif cached_token != token:
             raise AuthenticationFailed(_TOKEN_AUTH_FAILED)
         # if execution gets here the auth token is good
         # we include the organization id in the auth info


### PR DESCRIPTION
This was changed mistakenly during the Google Code-In (https://github.com/openwisp/openwisp-radius/commit/7803b91eba92447363ad604129d728f7d55b842b#diff-d40baa932501d0655680443a6bf8b008R30)
and the mistake went unnoticed (@cking100 FYI).