### PR TITLE
[qa] Improve 404 broken link check

### DIFF
--- a/docs/source/developer/how_to_extend.rst
+++ b/docs/source/developer/how_to_extend.rst
@@ -16,7 +16,7 @@ just replicate and adapt that code to get a basic derivative of
 *openwisp-radius* working.
 
 If you want to add new users fields, please follow the `tutorial to extend the
-openwisp-users <https://github.com/openwisp/openwisp-users/blob/master#extend-openwisp-users>`_.
+openwisp-users <https://github.com/openwisp/openwisp-users/#extend-openwisp-users>`_.
 As an example, we have extended *openwisp-users* to *sample_users* app and
 added a field ``social_security_number`` in the `sample_users/models.py
 <https://github.com/openwisp/openwisp-radius/blob/master/tests/openwisp2/sample_users/models.py>`_.

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -9,7 +9,7 @@ echo 'Checking documentation build status'
 if [[ $TRAVIS_PYTHON_VERSION != 3.6 ]]; then
     # check for broken link
     # remove condition when 3.6 is dropped
-    python -m http.server 8001 -d docs/build/ &>/dev/null &
+    python -m http.server 8001 -d docs/build/html/ &>/dev/null &
     pid=$!
     sleep 4
     pylinkvalidate.py http://localhost:8001/

--- a/runsphinx-build
+++ b/runsphinx-build
@@ -1,2 +1,4 @@
 #!/bin/bash
-sphinx-build -W -b html docs/source docs/build
+cd docs
+make html
+cd ..


### PR DESCRIPTION
The runsphinx-build created the build files in ./docs/build instead of
./docs/build/html like `make html` does.

This inconsistency caused that pylinkvalidator didn't spot internal
links returning 404.

Note: the crawler we use does not check external resources by default.
I gave it a run to check external resources and found 1 broken link to github, but I think we cannot do this in the build because the process is too slow.