### PR TITLE
[fix] decorate a function to reduce noises #83

### DIFF
--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -12,6 +12,8 @@ from ..utils import load_model
 from . import _TEST_DATE
 from .mixins import BaseTestCase
 
+from openwisp_utils.tests import capture_any_output
+
 User = get_user_model()
 PhoneToken = load_model('PhoneToken')
 RadiusToken = load_model('RadiusToken')
@@ -37,6 +39,7 @@ class TestPhoneToken(BaseTestCase):
         radius_settings.sms_sender = '+595972157632'
         radius_settings.save()
 
+    @capture_any_output()
     def _create_token(
         self, user=None, ip='127.0.0.1', phone_number='+393664351808', created=None
     ):


### PR DESCRIPTION
I used `./manage.py test openwisp_radius.tests.test_token.TestPhoneToken._create_token` to test the function to check if the decoraor is supressing the noise, but even after applying it I get the same output.

Before and after applying the decorator
```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
/home/priyanshu/anaconda3/envs/radius/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1312: RuntimeWarning: DateTimeField PhoneToken.created received a naive datetime (2020-12-22 00:00:00) while time zone support is active.
  RuntimeWarning)
/home/priyanshu/anaconda3/envs/radius/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1312: RuntimeWarning: DateTimeField PhoneToken.created received a naive datetime (2020-12-23 00:00:00) while time zone support is active.
  RuntimeWarning)
from: +595972157632
to: +393664351808
flash: False
test org verification code: 507357
-------------------------------------------------------------------------------
.
Summary of slow tests (>0.3s)


Total slow tests detected: 0

----------------------------------------------------------------------
Ran 1 test in 0.161s

OK
Destroying test database for alias 'default'...
```

Issue #83 