### PR TITLE
[radius-tests] Avoid error logging to print noisy output during tests…

### DIFF
--- a/openwisp_radius/tests/test_admin.py
+++ b/openwisp_radius/tests/test_admin.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
+from openwisp_utils.tests import capture_any_output
 
 from .. import settings as app_settings
 from ..base.models import _GET_IP_LIST_HELP_TEXT
@@ -143,6 +144,7 @@ class TestAdmin(
         self.assertContains(response, 'ok')
         self.assertNotContains(response, 'errors')
 
+    @capture_any_output()
     def test_radiusaccounting_change(self):
         options = dict(
             unique_id='2',
@@ -389,6 +391,7 @@ class TestAdmin(
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'field-number_of_users')
 
+    @capture_any_output()
     def test_radiusbatch_delete_methods(self):
         n = User.objects.count()
         options = dict(
@@ -818,6 +821,7 @@ class TestAdmin(
             select_widget=True,
         )
 
+    @capture_any_output()
     def test_radiuscheck_user_fk_queryset(self):
         data = self._create_multitenancy_test_env()
         self._test_multitenant_admin(
@@ -845,6 +849,7 @@ class TestAdmin(
             select_widget=True,
         )
 
+    @capture_any_output()
     def test_radiusreply_user_fk_queryset(self):
         data = self._create_multitenancy_test_env()
         self._test_multitenant_admin(
@@ -932,6 +937,7 @@ class TestAdmin(
             hidden=[data['rg2']],
         )
 
+    @capture_any_output()
     def test_radius_usergroup_user_fk_queryset(self):
         data = self._create_multitenancy_test_env(usergroup=True)
         self._test_multitenant_admin(
@@ -978,6 +984,7 @@ class TestAdmin(
             hidden=[data['rg2']],
         )
 
+    @capture_any_output()
     def test_radiustoken_delete_queryset(self):
         # Create & check radius token works
         self._get_org_user()

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -6,6 +6,8 @@ from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.utils.timezone import now
 
+from openwisp_utils.tests import capture_any_output, capture_stdout
+
 from ..utils import load_model
 from . import _RADACCT, CallCommandMixin, FileMixin
 from .mixins import BaseTestCase
@@ -17,6 +19,7 @@ RadiusPostAuth = load_model('RadiusPostAuth')
 
 
 class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
+    @capture_any_output()
     def test_cleanup_stale_radacct_command(self):
         options = _RADACCT.copy()
         options['unique_id'] = '117'
@@ -27,6 +30,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         self.assertNotEqual(session.session_time, None)
         self.assertEqual(session.update_time, session.stop_time)
 
+    @capture_any_output()
     def test_delete_old_postauth_command(self):
         options = dict(username='steve', password='jones', reply='value1')
         self._create_radius_postauth(**options)
@@ -34,6 +38,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         call_command('delete_old_postauth', 3)
         self.assertEqual(RadiusPostAuth.objects.filter(username='steve').count(), 0)
 
+    @capture_any_output()
     def test_delete_old_radacct_command(self):
         options = _RADACCT.copy()
         options['stop_time'] = '2017-06-10 11:50:00'
@@ -43,6 +48,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         call_command('delete_old_radacct', 3)
         self.assertEqual(RadiusAccounting.objects.filter(unique_id='666').count(), 0)
 
+    @capture_stdout()
     def test_batch_add_users_command(self):
         self.assertEqual(RadiusBatch.objects.all().count(), 0)
         path = self._get_path('static/test_batch.csv')
@@ -76,6 +82,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             )
             self._call_command('batch_add_users', **options)
 
+    @capture_stdout()
     def test_deactivate_expired_users_command(self):
         path = self._get_path('static/test_batch.csv')
         options = dict(
@@ -89,6 +96,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         call_command('deactivate_expired_users')
         self.assertEqual(get_user_model().objects.filter(is_active=True).count(), 0)
 
+    @capture_stdout()
     def test_delete_old_users_command(self):
         path = self._get_path('static/test_batch.csv')
         options = dict(
@@ -113,6 +121,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         call_command('delete_old_users', older_than_months=12)
         self.assertEqual(get_user_model().objects.all().count(), 0)
 
+    @capture_stdout()
     def test_prefix_add_users_command(self):
         self.assertEqual(RadiusBatch.objects.all().count(), 0)
         output_pdf = os.path.join(settings.MEDIA_ROOT, 'test_prefix10.pdf')

--- a/openwisp_radius/tests/test_social.py
+++ b/openwisp_radius/tests/test_social.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
 
+from openwisp_utils.tests import capture_stderr
+
 from ..utils import load_model
 from .mixins import ApiTokenMixin, BaseTestCase
 
@@ -23,6 +25,7 @@ class TestSocial(ApiTokenMixin, BaseTestCase):
         r = self.client.get(reverse(self.view_name, args=['wrong']), {'cp': 'test'})
         self.assertEqual(r.status_code, 404)
 
+    @capture_stderr()
     def test_redirect_cp_suspicious_400(self):
         u = self._create_social_user()
         u.is_staff = True

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -6,6 +6,8 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
+from openwisp_utils.tests import capture_any_output, capture_stdout
+
 from .. import exceptions
 from .. import settings as app_settings
 from ..utils import load_model
@@ -58,6 +60,7 @@ class TestPhoneToken(BaseTestCase):
         token.save()
         return token
 
+    @capture_any_output()
     def test_is_already_active(self):
         token = self._create_token()
         token.user.is_active = True
@@ -89,12 +92,14 @@ class TestPhoneToken(BaseTestCase):
         self.assertIsInstance(token.token, str)
         self.assertIsInstance(int(token.token), int)
 
+    @capture_stdout()
     def test_is_valid(self):
         token = self._create_token()
         self.assertTrue(token.is_valid(token.token))
         self.assertEqual(token.attempts, 1)
         self.assertTrue(token.verified)
 
+    @capture_any_output()
     def test_max_attempts(self):
         token = self._create_token()
         self.assertEqual(token.attempts, 0)
@@ -116,6 +121,7 @@ class TestPhoneToken(BaseTestCase):
             self.fail('Exception not raised')
 
     @freeze_time(_TEST_DATE)
+    @capture_any_output()
     def test_expired(self):
         token = self._create_token()
         token.valid_until = timezone.now() - timedelta(days=1)
@@ -150,14 +156,17 @@ class TestPhoneToken(BaseTestCase):
             self.fail('ValidationError not raised')
 
     @freeze_time(_TEST_DATE)
+    @capture_any_output()
     def test_user_limit_timezone_causes_change_of_date(self):
         self._test_user_limit()
 
     @freeze_time('2019-04-20T15:05:13-04:00')
+    @capture_any_output()
     def test_user_limit(self):
         self._test_user_limit()
 
     @freeze_time(_TEST_DATE)
+    @capture_any_output()
     def test_ip_limit(self):
         self._create_tokens_limit_test()
         opts = {
@@ -177,6 +186,7 @@ class TestPhoneToken(BaseTestCase):
         else:
             self.fail('ValidationError not raised')
 
+    @capture_any_output()
     def test_user_without_phone(self):
         user = self._create_user(
             **{'username': 'tester', 'password': 'tester', 'is_active': False}


### PR DESCRIPTION
… #83

Identified and marked all noisy tests with either the @capture_stdout(), @capture_stderr() or @capture_any_output() decorators to reduce noise.

Fixes #83