### PR TITLE
[change] Make email lowercase during regsitration #224

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -350,6 +350,10 @@ class RegisterSerializer(
         adapter = get_adapter()
         user = adapter.new_user(request)
         self.cleaned_data = self.get_cleaned_data()
+        # ensuring email is always converted to lowercase
+        email = str(user.email)
+        email = email.lower()
+        user.email = email
         # commit=False does not save the user to the DB yet
         adapter.save_user(request, user, self, commit=False)
         # the custom_signup method contains the openwisp specific logic

--- a/openwisp_radius/tests/test_api.py
+++ b/openwisp_radius/tests/test_api.py
@@ -1096,6 +1096,16 @@ class TestApi(ApiTokenMixin, FileMixin, BaseTestCase):
         self.assertTrue(user.is_member(self.default_org))
         self.assertTrue(user.is_active)
 
+    def test_register_email_ignorecase(self):
+        user = self._create_user(
+            username='tester',
+            email='Tester@gmail.com',
+            phone_number='+237675679231',
+            password='tester',
+        )
+
+        self.assertEqual(user.email, 'tester@gmail.com')
+
     def test_register_error_missing_radius_settings(self):
         self.assertEqual(User.objects.count(), 0)
         self.default_org.radius_settings.delete()


### PR DESCRIPTION
Added a check to always convert user email to lowercase during registration. This will remove possibilities of user email clashes only due to difference in case of email. A unittest to verify that the email has been converted to lowercase has also been added.

Fixes #224