### PR TITLE
Update setup.rst

### DIFF
--- a/docs/source/developer/setup.rst
+++ b/docs/source/developer/setup.rst
@@ -140,10 +140,15 @@ Add the URLs to your main ``urls.py``:
 
     urlpatterns = [
         # ... other urls in your project ...
+        
+        # django admin interface urls
+        path('admin/', admin.site.urls),
         # openwisp-radius urls
-        path('admin/', admin.site.urls), # Web interface urls
+        path('api/v1/', include('openwisp_utils.api.urls')),
+        path('api/v1/', include('openwisp_users.api.urls')),
         path('accounts/', include('openwisp_users.accounts.urls')),
         path('', include('openwisp_radius.urls', namespace='radius'))
+        
     ]
 
 Then run:

--- a/docs/source/developer/setup.rst
+++ b/docs/source/developer/setup.rst
@@ -148,7 +148,6 @@ Add the URLs to your main ``urls.py``:
         path('api/v1/', include('openwisp_users.api.urls')),
         path('accounts/', include('openwisp_users.accounts.urls')),
         path('', include('openwisp_radius.urls', namespace='radius'))
-        
     ]
 
 Then run:

--- a/docs/source/developer/setup.rst
+++ b/docs/source/developer/setup.rst
@@ -141,6 +141,7 @@ Add the URLs to your main ``urls.py``:
     urlpatterns = [
         # ... other urls in your project ...
         # openwisp-radius urls
+        path('admin/', admin.site.urls), # Web interface urls
         path('accounts/', include('openwisp_users.accounts.urls')),
         path('', include('openwisp_radius.urls', namespace='radius'))
     ]


### PR DESCRIPTION
In the URLS configuration is missing the line to enable the web interface URL (/admin), in a stand-alone installation this piece of code is absolutely necessary.