### PR TITLE
[change] Make email lowercase during registration #224

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -350,6 +350,12 @@ class RegisterSerializer(
             phone_number = None
         return phone_number
 
+    def validate_email(self, email):
+        # Overriding validate_email method to convert email to lowercase.
+        # First the validated email is returned from DRF's field level email validator
+        # and the returned email is converted to lowercase
+        return super().validate_email(email).lower()
+
     def validate_optional_fields(self, field_name, field_value, org):
         field_setting = getattr(
             org.radius_settings, field_name

--- a/openwisp_radius/tests/test_api.py
+++ b/openwisp_radius/tests/test_api.py
@@ -1106,6 +1106,24 @@ class TestApi(ApiTokenMixin, FileMixin, BaseTestCase):
         self.assertTrue(user.is_member(self.default_org))
         self.assertTrue(user.is_active)
 
+    def test_lowercase_registration_email(self):
+        self._superuser_login()
+        self.assertEqual(User.objects.count(), 1)
+        url = reverse('radius:rest_register', args=[self.default_org.slug])
+        r = self.client.post(
+            url,
+            {
+                'username': 'Tester@example.com',
+                'email': 'Tester@example.com',
+                'password1': 'password',
+                'password2': 'password',
+            },
+        )
+        self.assertEqual(r.status_code, 201)
+        user = User.objects.get(email='tester@example.com')
+
+        self.assertEqual(user.email, 'tester@example.com')
+
     @mock.patch.object(
         app_settings,
         'OPTIONAL_REGISTRATION_FIELDS',


### PR DESCRIPTION
Added validation in RegisterSerializer to convert email to lowercase during registration. A unit test has also been added to test the same.

Fixes #224