### PR TITLE
[radius/registration] Email Verification added when sms verification is enabled #118

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -3,6 +3,7 @@ import logging
 import phonenumbers
 import swapper
 from allauth.account.adapter import get_adapter
+from allauth.account.models import EmailAddress
 from allauth.account.utils import setup_user_email
 from dj_rest_auth.registration.serializers import (
     RegisterSerializer as BaseRegisterSerializer,
@@ -391,6 +392,8 @@ class RegisterSerializer(
         except ValidationError as e:
             raise serializers.ValidationError(self._get_error_dict(e))
         user.save()
+        email = EmailAddress(user=user, email=user.email)
+        email.send_confirmation(request=request, signup=True)
         orgUser = OrganizationUser(organization=org, user=user)
         orgUser.full_clean()
         orgUser.save()


### PR DESCRIPTION
Used all-auth EmailAddress model in custom_signup to send_confirmation email.

Implemented the ideal solution: Verifying email address does not flag the
user as `is_active`.

Fixes #118

I am not sure about this is the best way but it implements the ideal solution mentioned in the issue.

Screenshot: 

Detail: Email received after making a POST request on the API endpoint for creating the user.

![image](https://user-images.githubusercontent.com/56037184/110751017-4eca7480-8269-11eb-8eb3-f1ee0919a377.png)