### PR TITLE
[bug] Email confirmation fix #243

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     # openwisp admin theme
     'openwisp_utils.admin_theme',
+    'openwisp_users.accounts',
     # all-auth
     'django.contrib.sites',
     'allauth',


### PR DESCRIPTION
Added `openwisp_users.accounts` to override default allauth-templates.

Closes #243