### PR TITLE
[feature] Allow specific methods to authorize unverified users

### DIFF
--- a/docs/source/user/settings.rst
+++ b/docs/source/user/settings.rst
@@ -479,6 +479,25 @@ For example:
     additional registration methods which are supported by multiple
     custom modules).
 
+.. warning::
+
+    If you need to implement a registration method that needs to grant limited
+    internet access to unverified users so they can complete their
+    verification process online on other websites which cannot be predicted
+    and hence cannot be added to the walled garden, you can pass
+    ``authorize_unverified=True`` to the ``register_registration_method``
+    function.
+
+    This is needed to implement payment flows in which users insert
+    a specific 3D secure code in the website of their bank.
+    Keep in mind that you should create a specific limited radius group
+    for these unverified users.
+
+    Payment flows and credit/debit card verification are fully implemented
+    in **OpenWISP Subscriptions**, a premium module available only to
+    customers of the
+    `commercial support offering of OpenWISP <../general/support.html>`_.
+
 Email related settings
 ======================
 

--- a/openwisp_radius/registration.py
+++ b/openwisp_radius/registration.py
@@ -10,10 +10,14 @@ REGISTRATION_METHOD_CHOICES = [
     ('mobile_phone', _('Mobile phone number verification via SMS')),
 ]
 
+AUTHORIZE_UNVERIFIED = []
+
 logger = logging.getLogger(__name__)
 
 
-def register_registration_method(name, verbose_name, fail_loud=True):
+def register_registration_method(
+    name, verbose_name, authorize_unverified=False, fail_loud=True
+):
     # check if it's a duplicate
     duplicate = False
     for method_tuple in REGISTRATION_METHOD_CHOICES:
@@ -27,6 +31,10 @@ def register_registration_method(name, verbose_name, fail_loud=True):
         raise ImproperlyConfigured(f'Method {name} is already registered')
     else:
         logger.info(f'Method {name} is already registered')
+    # needed to implement 3D secure verification
+    # when doing credit/debit card payments
+    if authorize_unverified and name not in AUTHORIZE_UNVERIFIED:
+        AUTHORIZE_UNVERIFIED.append(name)
 
 
 def unregister_registration_method(name, fail_loud=True):


### PR DESCRIPTION
This is needed to implement payment flows in which the user
needs to reach the website of their bank or, more in general,
whenever a registration method needs the user to complete
the final part of the registration online on website URLs
which cannot be predicted and hence cannot be added to
the walled garden.