### PR TITLE
[fix] Added validation of phone number uniqueness

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -352,11 +352,15 @@ class RegisterSerializer(
         org = self.context['view'].organization
         if is_sms_verification_enabled(org):
             if not phone_number:
-                raise serializers.ValidationError(_('This field is required'))
+                raise serializers.ValidationError(_('This field is required.'))
             mobile_prefixes = org.radius_settings.allowed_mobile_prefixes_list
             if not self.is_prefix_allowed(phone_number, mobile_prefixes):
                 raise serializers.ValidationError(
                     _('This international mobile prefix is not allowed.')
+                )
+            if User.objects.filter(phone_number=phone_number).exists():
+                raise serializers.ValidationError(
+                    _('A user is already registered with this phone number.')
                 )
         else:
             # Phone number should not be stored if sms verification is disabled

--- a/openwisp_radius/tests/mixins.py
+++ b/openwisp_radius/tests/mixins.py
@@ -126,9 +126,10 @@ class ApiTokenMixin(BasePostParamsMixin):
         self.auth_header = f'Bearer {org.pk} {rad.token}'
         self.token_querystring = f'?token={rad.token}&uuid={str(org.pk)}'
 
-    def _register_user(self, extra_params=None):
+    def _register_user(self, extra_params=None, expect_201=True, expect_users=1):
         self._superuser_login()
-        self.assertEqual(User.objects.count(), 1)
+        if expect_users is not None:
+            self.assertEqual(User.objects.count(), expect_users)
         url = reverse('radius:rest_register', args=[self.default_org.slug])
         params = {
             'username': self._test_email,
@@ -139,7 +140,8 @@ class ApiTokenMixin(BasePostParamsMixin):
         if extra_params:
             params.update(extra_params)
         response = self.client.post(url, params,)
-        self.assertEqual(response.status_code, 201)
+        if expect_201:
+            self.assertEqual(response.status_code, 201)
         return response
 
     def _radius_batch_csv_data(self, **kwargs):

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -147,6 +147,13 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertTrue(user.is_active)
         self.assertFalse(user.registered_user.is_verified)
 
+    def test_register_400_duplicate_user(self):
+        self.test_register_201()
+        r = self._register_user(expect_201=False, expect_users=None)
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('username', r.data)
+        self.assertIn('email', r.data)
+
     def test_radius_user_serializer(self):
         self._register_user()
         try:

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -40,8 +40,10 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         'method': 'mobile_phone',
     }
 
-    def _register_user(self):
-        return super()._register_user(extra_params=self._extra_registration_params)
+    def _register_user(self, **kwargs):
+        return super()._register_user(
+            extra_params=self._extra_registration_params, **kwargs
+        )
 
     def test_register_201_mobile_phone_verification(self):
         r = self._register_user()
@@ -90,6 +92,14 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         self.assertEqual(r.status_code, 400)
         self.assertIn('phone_number', r.data)
         self.assertEqual(User.objects.count(), 2)
+
+    def test_register_400_duplicate_user(self):
+        self.test_register_201_mobile_phone_verification()
+        r = self._register_user(expect_201=False, expect_users=None)
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('username', r.data)
+        self.assertIn('email', r.data)
+        self.assertIn('phone_number', r.data)
 
     def test_create_phone_token_401(self):
         url = reverse('radius:phone_token_create', args=[self.default_org.slug])


### PR DESCRIPTION
If a user tries to register with username and phone number which
are already in use, only the username error is shown because
django rest auth has a validation method for this field,
but for the phone number uniqueness we rely on model validation,
which is not performed if the serializer level validation fails.

Adding a validation level serialzier for phone number too,
so that both username and phone_number are incldued in
the error response.