### PR TITLE
[i18n] Added translations of user facing API responses for it, de, sl + fixes and improvements

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -84,16 +84,16 @@ class FreeradiusApiAuthentication(BaseAuthentication):
                     return (AnonymousUser(), uuid)
             except ValueError:
                 invalid_addr_message = _(
-                    f'Request rejected: ({ip}) in organization settings or '
+                    'Request rejected: ({ip}) in organization settings or '
                     'settings.py is not a valid IP address. '
                     'Please contact administrator.'
-                )
+                ).format(ip=ip)
                 logger.warning(invalid_addr_message)
                 raise AuthenticationFailed(invalid_addr_message)
         message = _(
-            f'Request rejected: Client IP address ({client_ip}) is not in '
+            'Request rejected: Client IP address ({client_ip}) is not in '
             'the list of IP addresses allowed to consume the freeradius API.'
-        )
+        ).format(client_ip=client_ip)
         logger.warning(message)
         raise AuthenticationFailed(message)
 

--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -68,7 +68,10 @@ class AuthTokenSerializer(BaseAuthTokenSerializer):
                 password=password,
             )
             if not user:
-                msg = _('Unable to log in with provided credentials.')
+                msg = _(
+                    'The credentials entered are not valid. '
+                    'Please double-check and try again.'
+                )
                 raise serializers.ValidationError(msg, code='authorization')
         else:
             msg = _('Must include "username" and "password".')
@@ -189,9 +192,7 @@ class RadiusAccountingSerializer(serializers.ModelSerializer):
             try:
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
-                logging.warning(
-                    _(f'No corresponding user found for username: {username}')
-                )
+                logging.warning(f'No corresponding user found for username: {username}')
             else:
                 group = user.radiususergroup_set.order_by('priority').first()
                 groupname = group.groupname if group else None

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -126,9 +126,8 @@ class DispatchOrgMixin(object):
     def validate_membership(self, user):
         if not (user.is_superuser or user.is_member(self.organization)):
             message = _(
-                f'User {user.username} is not member of '
-                f'organization {self.organization.slug}.'
-            )
+                'The user {username} is not member of organization {organization}.'
+            ).format(username=user.username, organization=self.organization.name)
             logger.warning(message)
             raise serializers.ValidationError({'non_field_errors': [message]})
 
@@ -418,7 +417,7 @@ class PasswordResetView(ThrottledAPIMixin, DispatchOrgMixin, BasePasswordResetVi
     @swagger_auto_schema(
         responses={
             200: '`{"detail": "Password reset e-mail has been sent."}`',
-            400: '`{"detail": "email field is required"}`',
+            400: '`{"detail": "The email field is required."}`',
             404: '`{"detail": "Not found."}`',
         }
     )
@@ -457,7 +456,7 @@ class PasswordResetView(ThrottledAPIMixin, DispatchOrgMixin, BasePasswordResetVi
             user = get_object_or_404(User, email=email)
             self.validate_membership(user)
             return user
-        raise ParseError(_('email field is required'))
+        raise ParseError(_('The email field is required.'))
 
 
 password_reset = PasswordResetView.as_view()

--- a/openwisp_radius/base/validators.py
+++ b/openwisp_radius/base/validators.py
@@ -8,6 +8,6 @@ def ipv6_network_validator(value):
     try:
         network = ip_network(value)
     except Exception as error:
-        raise ValidationError(_(f'Invalid ipv6 prefix: {error}'))
+        raise ValidationError(_('Invalid ipv6 prefix: {error}').format(error=error))
     if not isinstance(network, IPv6Network):
-        raise ValidationError(_(f'{value} is not an IPv6 prefix'))
+        raise ValidationError(_('{value} is not an IPv6 prefix').format(value=value))

--- a/openwisp_radius/locale/de/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,131 @@
+# OpenWISP RADIUS
+# Copyright (C) 2021
+# This file is distributed under the same license as the PACKAGE package.
+# Federico Capoano support@openwisp.io, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: openwisp_radius/api/serializers.py:71
+msgid ""
+"The credentials entered are not valid. Please double-check and try again."
+msgstr ""
+"Die eingegebenen Zugangsdaten sind ungültig. Bitte überprüfen Sie es noch einmal und versuchen Sie es erneut."
+
+#: openwisp_radius/api/serializers.py:74
+msgid "Must include \"username\" and \"password\"."
+msgstr "Muss \"Benutzername\" und \"Passwort\" enthalten."
+
+#: openwisp_radius/api/serializers.py:332
+msgid ""
+"Required only when the organization has enabled SMS verification in its "
+"\"Organization RADIUS Settings.\""
+msgstr ""
+
+#: openwisp_radius/api/serializers.py:344
+msgid ""
+"Required only when the organization has mandatory identity verification in "
+"its \"Organization RADIUS Settings.\""
+msgstr ""
+
+#: openwisp_radius/api/serializers.py:355
+#: openwisp_radius/api/serializers.py:383
+msgid "This field is required."
+msgstr "Dieses Feld wird benötigt."
+
+#: openwisp_radius/api/serializers.py:363
+msgid "A user is already registered with this phone number."
+msgstr "Ein Benutzer ist bereits mit dieser Telefonnummer registriert."
+
+#: openwisp_radius/api/serializers.py:447
+msgid "The new phone number must be different than the old one."
+msgstr "Die neue Telefonnummer muss sich von der alten unterscheiden."
+
+#: openwisp_radius/api/views.py:129
+#, python-brace-format
+msgid ""
+"The user {username} is not member of organization {organization}."
+msgstr ""
+"Benutzer {username} ist kein Mitglied der Organisation {organization}."
+
+#: openwisp_radius/api/views.py:459
+msgid "The email field is required."
+msgstr "Das E-Mail-Feld ist erforderlich."
+
+#: openwisp_radius/api/views.py:570
+msgid "No verification code found in the system for this user."
+msgstr "Für diesen Benutzer wurde kein Verifizierungscode im System gefunden."
+
+#: openwisp_radius/api/views.py:577
+msgid "Invalid code."
+msgstr "Ungültiger Code."
+
+#: openwisp_radius/base/models.py:145 openwisp_radius/base/models.py:879
+#: openwisp_radius/base/models.py:883
+msgid "This field cannot be blank."
+msgstr "Dieses Feld darf nicht leer sein."
+
+#: openwisp_radius/base/models.py:1279
+msgid "Maximum daily limit reached."
+msgstr "Maximales Tageslimit erreicht."
+
+#: openwisp_radius/base/models.py:1292
+msgid "Maximum daily limit reached from this ip address."
+msgstr "Maximales Tageslimit von dieser IP-Adresse erreicht."
+
+#: openwisp_radius/base/models.py:1307
+#, python-brace-format
+msgid "The user {user} is not member of any organization"
+msgstr "Der Benutzer {user} ist kein Mitglied einer Organisation."
+
+#: openwisp_radius/base/models.py:1311
+#, python-brace-format
+msgid "{organization} verification code: {code}"
+msgstr ""
+"{organization}-Bestätigungscode: {code}"
+
+#: openwisp_radius/base/models.py:1335
+msgid "This user is already verified."
+msgstr "Dieser Benutzer ist bereits verifiziert."
+
+#: openwisp_radius/base/models.py:1350
+msgid ""
+"Maximum number of allowed attempts reached for this verification code, "
+"please send a new code and try again."
+msgstr ""
+"Maximale Anzahl zulässiger Versuche für diesen Bestätigungscode erreicht"
+"Bitte senden Sie einen neuen Code und versuchen Sie es erneut."
+
+#: openwisp_radius/base/models.py:1364
+msgid ""
+"This verification code has expired, Please send a new code and try again."
+msgstr "Dieser Bestätigungscode ist abgelaufen. Bitte senden Sie einen neuen Code und versuchen Sie es erneut."
+
+#: openwisp_radius/templates/custom_password_reset_email.html:2
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at\n"
+"%(site_name)s."
+msgstr ""
+"Sie erhalten diese E-Mail, weil Sie eine Passwortzurücksetzung für Ihre "
+"Benutzerkonto bei\n"
+"%(site_name)s."
+
+#: openwisp_radius/templates/custom_password_reset_email.html:5
+msgid "Please go to the following page and choose a new password:"
+msgstr "Bitte gehen Sie auf die folgende Seite und wählen Sie ein neues Passwort:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:10
+msgid "Your username, in case you've forgotten:"
+msgstr "Ihr Benutzername, falls Sie ihn vergessen haben:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:12
+msgid "Best regards"
+msgstr "Mit freundlichen Grüßen"

--- a/openwisp_radius/locale/it/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,137 @@
+# OpenWISP RADIUS
+# Copyright (C) 2021
+# This file is distributed under the same license as the PACKAGE package.
+# Federico Capoano support@openwisp.io, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: openwisp_radius/api/serializers.py:71
+msgid ""
+"The credentials entered are not valid. Please double-check and try again."
+msgstr ""
+"Le credenziali inserite non sono valide. Si prega di controllare e riprovare."
+
+#: openwisp_radius/api/serializers.py:74
+msgid "Must include \"username\" and \"password\"."
+msgstr "Deve includere \"nome utente\" e \"password\"."
+
+#: openwisp_radius/api/serializers.py:332
+msgid ""
+"Required only when the organization has enabled SMS verification in its "
+"\"Organization RADIUS Settings.\""
+msgstr ""
+
+#: openwisp_radius/api/serializers.py:344
+msgid ""
+"Required only when the organization has mandatory identity verification in "
+"its \"Organization RADIUS Settings.\""
+msgstr ""
+
+#: openwisp_radius/api/serializers.py:355
+#: openwisp_radius/api/serializers.py:383
+msgid "This field is required."
+msgstr "Queso campo è obbligatorio."
+
+#: openwisp_radius/api/serializers.py:363
+msgid "A user is already registered with this phone number."
+msgstr "Un utente è già registrato con questo numero di telefono."
+
+#: openwisp_radius/api/serializers.py:447
+msgid "The new phone number must be different than the old one."
+msgstr "Il nuovo numero di telefono deve essere diverso da quello vecchio."
+
+#: openwisp_radius/api/views.py:129
+#, python-brace-format
+msgid ""
+"The user {username} is not member of organization {organization}."
+msgstr ""
+"L'utente {username} non è membro dell'organizzazione {organization}."
+
+#: openwisp_radius/api/views.py:459
+msgid "The email field is required."
+msgstr "Il campo email è obbligatorio."
+
+#: openwisp_radius/api/views.py:570
+msgid "No verification code found in the system for this user."
+msgstr "Nessun codice di verifica trovato nel sistema per questo utente."
+
+#: openwisp_radius/api/views.py:577
+msgid "Invalid code."
+msgstr "Codice non valido."
+
+#: openwisp_radius/base/models.py:145 openwisp_radius/base/models.py:879
+#: openwisp_radius/base/models.py:883
+msgid "This field cannot be blank."
+msgstr "Questo campo non può essere vuoto."
+
+#: openwisp_radius/base/models.py:1279
+msgid "Maximum daily limit reached."
+msgstr "Limite giornaliero massimo raggiunto."
+
+#: openwisp_radius/base/models.py:1292
+msgid "Maximum daily limit reached from this ip address."
+msgstr "Limite giornaliero massimo raggiunto da questo indirizzo IP."
+
+#: openwisp_radius/base/models.py:1307
+#, python-brace-format
+msgid "The user {user} is not member of any organization"
+msgstr "L'utente {user} non è membro di alcuna organizzazione."
+
+#: openwisp_radius/base/models.py:1311
+#, python-brace-format
+msgid "{organization} verification code: {code}"
+msgstr ""
+"Codice di verifica {organization}: {code}"
+
+#: openwisp_radius/base/models.py:1335
+msgid "This user is already verified."
+msgstr "Questo utente è giá verificato."
+
+#: openwisp_radius/base/models.py:1350
+msgid ""
+"Maximum number of allowed attempts reached for this verification code, "
+"please send a new code and try again."
+msgstr ""
+"Numero massimo di tentativi consentiti raggiunto per questo codice di "
+"verifica, invia un nuovo codice e riprova."
+
+#: openwisp_radius/base/models.py:1364
+msgid ""
+"This verification code has expired, Please send a new code and try again."
+msgstr "Questo codice di verifica è scaduto. Invia un nuovo codice e riprova."
+
+#: openwisp_radius/base/models.py:1381
+msgid ""
+"users can sign up in different ways, some methods are valid as indirect "
+"identity verification (eg: mobile phone SIM card in most countries)"
+msgstr ""
+
+#: openwisp_radius/templates/custom_password_reset_email.html:2
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at\n"
+"%(site_name)s."
+msgstr ""
+"Hai ricevuto questa email perché hai richiesto la reimpostazione della "
+"password per il tuo account utente su\n"
+"%(site_name)s."
+
+#: openwisp_radius/templates/custom_password_reset_email.html:5
+msgid "Please go to the following page and choose a new password:"
+msgstr "La preghiamo di aprire la pagina seguente per scegliere una nuova password:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:10
+msgid "Your username, in case you've forgotten:"
+msgstr "Il suo nome utente, nel caso l'avesse dimenticato:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:12
+msgid "Best regards"
+msgstr "Distinti saluti"

--- a/openwisp_radius/locale/sl/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/sl/LC_MESSAGES/django.po
@@ -1,0 +1,136 @@
+# OpenWISP RADIUS
+# Copyright (C) 2021
+# This file is distributed under the same license as the PACKAGE package.
+# Federico Capoano support@openwisp.io, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+
+#: openwisp_radius/api/serializers.py:71
+msgid ""
+"The credentials entered are not valid. Please double-check and try again."
+msgstr ""
+"Vnesene poverilnice niso veljavne. Preverite še enkrat in poskusite znova."
+
+#: openwisp_radius/api/serializers.py:74
+msgid "Must include \"username\" and \"password\"."
+msgstr "Mora vključevati \"uporabniško ime\" in \"geslo\"."
+
+#: openwisp_radius/api/serializers.py:332
+msgid ""
+"Required only when the organization has enabled SMS verification in its "
+"\"Organization RADIUS Settings.\""
+msgstr ""
+"Zahtevano samo, če je organizacija omogočila preverjanje SMS v svojem"
+"\"Nastavitve RADIUS organizacije.\""
+
+#: openwisp_radius/api/serializers.py:344
+msgid ""
+"Required only when the organization has mandatory identity verification in "
+"its \"Organization RADIUS Settings.\""
+msgstr ""
+"Potrebno le, če ima organizacija obvezno preverjanje identitete v"
+"its \"Nastavitve RADIUS -a organizacije.\""
+
+#: openwisp_radius/api/serializers.py:355
+#: openwisp_radius/api/serializers.py:383
+msgid "This field is required."
+msgstr "To polje je obvezno."
+
+#: openwisp_radius/api/serializers.py:363
+msgid "A user is already registered with this phone number."
+msgstr "Uporabnik je že registriran s to telefonsko številko."
+
+#: openwisp_radius/api/serializers.py:447
+msgid "The new phone number must be different than the old one."
+msgstr "Nova telefonska številka se mora razlikovati od stare."
+
+#: openwisp_radius/api/views.py:129
+#, python-brace-format
+msgid ""
+"The user {username} is not member of organization {organization}."
+msgstr ""
+"Uporabnik {username} ni član organizacije {organization}."
+
+#: openwisp_radius/api/views.py:459
+msgid "The email field is required."
+msgstr "Polje za e -poštno sporočilo je obvezno."
+
+#: openwisp_radius/api/views.py:570
+msgid "No verification code found in the system for this user."
+msgstr "Za tega uporabnika v sistemu ni najdene verifikacijske kode."
+
+#: openwisp_radius/api/views.py:577
+msgid "Invalid code."
+msgstr "Neveljavna koda."
+
+#: openwisp_radius/base/models.py:145 openwisp_radius/base/models.py:879
+#: openwisp_radius/base/models.py:883
+msgid "This field cannot be blank."
+msgstr "To polje ne more biti prazno."
+
+#: openwisp_radius/base/models.py:1279
+msgid "Maximum daily limit reached."
+msgstr "Največja dnevna meja je dosežena."
+
+#: openwisp_radius/base/models.py:1292
+msgid "Maximum daily limit reached from this ip address."
+msgstr "Največja dnevna omejitev, dosežena s tega naslova IP."
+
+#: openwisp_radius/base/models.py:1307
+#, python-brace-format
+msgid "The user {user} is not member of any organization"
+msgstr "Uporabnik {user} ni član nobene organizacije."
+
+#: openwisp_radius/base/models.py:1311
+#, python-brace-format
+msgid "{organization} verification code: {code}"
+msgstr "{organization} koda za preverjanje: {code}"
+
+#: openwisp_radius/base/models.py:1335
+msgid "This user is already verified."
+msgstr "Ta uporabnik je že preverjen."
+
+#: openwisp_radius/base/models.py:1350
+msgid ""
+"Maximum number of allowed attempts reached for this verification code, "
+"please send a new code and try again."
+msgstr ""
+"Največje dovoljeno število poskusov za to kodo za preverjanje,"
+"pošljite novo kodo in poskusite znova."
+
+#: openwisp_radius/base/models.py:1364
+msgid ""
+"This verification code has expired, Please send a new code and try again."
+msgstr ""
+"Ta koda za preverjanje je potekla. Pošljite novo kodo in poskusite znova."
+
+#: openwisp_radius/templates/custom_password_reset_email.html:2
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at\n"
+"%(site_name)s."
+msgstr ""
+"To e -poštno sporočilo ste prejeli, ker ste zahtevali ponastavitev gesla za svoj"
+"uporabniški račun na\n"
+"%(site_name)s."
+
+#: openwisp_radius/templates/custom_password_reset_email.html:5
+msgid "Please go to the following page and choose a new password:"
+msgstr "Pojdite na naslednjo stran in izberite novo geslo:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:10
+msgid "Your username, in case you've forgotten:"
+msgstr "Vaše uporabniško ime, če ste pozabili:"
+
+#: openwisp_radius/templates/custom_password_reset_email.html:12
+msgid "Best regards"
+msgstr "Lep pozdrav"

--- a/openwisp_radius/settings.py
+++ b/openwisp_radius/settings.py
@@ -17,10 +17,8 @@ DEBUG = settings.DEBUG
 def get_settings_value(option, default):
     if hasattr(settings, f'DJANGO_FREERADIUS_{option}'):  # pragma: no cover
         logger.warning(
-            _(
-                f'DJANGO_FREERADIUS_{option} setting is deprecated. It will be '
-                f'removed in the future, please use OPENWISP_RADIUS_{option} instead.'
-            )
+            f'DJANGO_FREERADIUS_{option} setting is deprecated. It will be '
+            f'removed in the future, please use OPENWISP_RADIUS_{option} instead.'
         )
         return getattr(settings, f'DJANGO_FREERADIUS_{option}')
     return getattr(settings, f'OPENWISP_RADIUS_{option}', default)

--- a/openwisp_radius/templates/custom_password_reset_email.html
+++ b/openwisp_radius/templates/custom_password_reset_email.html
@@ -9,8 +9,6 @@
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
 
-{% trans "Thanks for using our site!" %}
-
-{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
-
+{% trans "Best regards" %}
+{{ site_name }}
 {% endautoescape %}

--- a/openwisp_radius/templates/djangosaml2/auth_error.html
+++ b/openwisp_radius/templates/djangosaml2/auth_error.html
@@ -3,10 +3,9 @@
 
 {% block content %}
     <h1>{% trans "Authorization error" %}</h1>
-    <p>{% blocktrans %}You are already logged in and you are trying to go to the login page again.{% endblocktrans %}</p>
-
+    <p>{% blocktrans %}You are already logged in and you are trying to access the login page again.{% endblocktrans %}</p>
     <p>{% blocktrans %}You may have been redirected here when trying to access some content
        that required extra privileges that you do not have.{% endblocktrans %}</p>
-
-    <p>{% trans "Please" %} <a href="{% url 'radius:saml2_logout' %}">{% trans "logout" %}</a> {% trans "and login as a different user" %}</p>
+    <p>{% trans "Please logout and login as a different user" %}.</p>
+    <p><a class="button" href="{% url 'radius:saml2_logout' %}">{% trans "logout" %}</a></p>
 {% endblock %}

--- a/openwisp_radius/tests/test_api/test_rest_token.py
+++ b/openwisp_radius/tests/test_api/test_rest_token.py
@@ -77,7 +77,9 @@ class TestApiUserToken(ApiTokenMixin, BaseTestCase):
         url = self._get_url()
         r = self.client.post(url, {'username': 'tester', 'password': 'tester'})
         self.assertEqual(r.status_code, 400)
-        self.assertIn('Unable to log in', r.json()['non_field_errors'][0])
+        self.assertIn(
+            'credentials entered are not valid', r.json()['non_field_errors'][0]
+        )
 
     @capture_any_output()
     def test_user_auth_token_400_organization(self):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
     install_requires=[
         'django>=3.0,<3.2',
         'swapper~=1.1.0',
+        # Needed for the new authentication backend in openwisp-users
+        # TODO: remove when the new version of openwisp-users is released
+        'openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/master',
         # TODO: change this when next point version of openwisp-utils is released
         (
             'openwisp-utils[rest] @'
@@ -45,9 +48,6 @@ setup(
         'passlib~=1.7.1',
         'djangorestframework-link-header-pagination~=0.1.1',
         'weasyprint>=43,<53',
-        # Needed for the new authentication backend in openwisp-users
-        # TODO: remove when the new version of openwisp-users is released
-        'openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/master',
         'dj-rest-auth~=2.1.6',
         'django-sendsms~=0.4.0',
         'jsonfield~=3.1.0',


### PR DESCRIPTION
[i18n] Added translations of user facing API responses for it, de, sl
[misc] Moved openwisp-users before openwisp-utils in install_requires
[fix] Fixed issues with translatable strings
- let's not translate log lines because these won't be shown to end users
- gettext does not work with fstrings,
  therefore the use of str.format() has been restored
- improved some user facing strings
