### PR TITLE
[fix] Used openwisp-users auth backend to filter user in FreeradiusAPIAuthentication #292

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -106,7 +106,9 @@ class FreeradiusApiAuthentication(BaseAuthentication):
             return self._check_client_ip_and_return(request, cached_orgid)
         else:
             try:
-                radtoken = RadiusToken.objects.get(user__username=username)
+                radtoken = RadiusToken.objects.get(
+                    user=auth_backend.get_users(username).first()
+                )
             except RadiusToken.DoesNotExist:
                 if username:
                     message = _(

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -132,16 +132,38 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data, {'control:Auth-Type': 'Accept'})
 
+    def _test_authorize_without_auth_helper(self, username, password):
+        r = self._authorize_user(username=username, password=password)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data, {'control:Auth-Type': 'Accept'})
+
     def test_authorize_with_user_auth(self):
+        user = self._create_user(
+            username='tester2',
+            email='tester2@gmail.com',
+            phone_number='+237675679232',
+            password='tester',
+        )
+
+        self._create_org_user(organization=self._get_org(), user=user)
+
+        with self.subTest('Test authorize with username'):
+            self._test_authorize_with_user_auth_helper(user.username, 'tester')
+
+        with self.subTest('Test authorize with email'):
+            self._test_authorize_with_user_auth_helper(user.email, 'tester')
+
+        with self.subTest('Test authorize with phone_number'):
+            self._test_authorize_with_user_auth_helper(user.phone_number, 'tester')
+
+    def test_authorize_without_user_auth(self):
         user = self._create_user(
             username='tester',
             email='tester@gmail.com',
             phone_number='+237675679231',
             password='tester',
         )
-
         self._create_org_user(organization=self._get_org(), user=user)
-
         with self.subTest('Test authorize with username'):
             self._test_authorize_with_user_auth_helper('tester', 'tester')
 
@@ -1187,7 +1209,7 @@ class TestClientIpApi(ApiTokenMixin, BaseTestCase):
         org = self._get_org()
         self.assertEqual(cache.get(f'ip-{org.pk}'), None)
         with self.subTest('Without Cache'):
-            authorize_and_asset(5, [])
+            authorize_and_asset(6, [])
         with self.subTest('With Cache'):
             authorize_and_asset(3, [])
         with self.subTest('Organization Settings Updated'):
@@ -1197,7 +1219,7 @@ class TestClientIpApi(ApiTokenMixin, BaseTestCase):
             authorize_and_asset(3, ['127.0.0.1', '192.0.2.0'])
         with self.subTest('Cache Deleted'):
             cache.clear()
-            authorize_and_asset(5, ['127.0.0.1', '192.0.2.0'])
+            authorize_and_asset(6, ['127.0.0.1', '192.0.2.0'])
 
     def test_ip_from_setting_valid(self):
         response = self.client.post(reverse('radius:authorize'), self.params)


### PR DESCRIPTION
Used authentication backend of openwisp-users to filter users with the username,
email and mobile phone.
Also, added a failing test for this.

Fixes #292