### PR TITLE
[fix] Accounting-On status type with blank username returns 403 #298

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -29,6 +29,9 @@ from .serializers import (
 from .utils import IDVerificationHelper
 
 _TOKEN_AUTH_FAILED = _('Token authentication failed')
+# Accounting-On and Accounting-Off are not implemented and
+# hence  ignored right now - may be implemented in the future
+UNSUPPORTED_STATUS_TYPES = ['Accounting-On', 'Accounting-Off']
 logger = logging.getLogger(__name__)
 
 RadiusToken = load_model('RadiusToken')
@@ -98,6 +101,8 @@ class FreeradiusApiAuthentication(BaseAuthentication):
         raise AuthenticationFailed(message)
 
     def _radius_token_authenticate(self, request):
+        if request.data.get('status_type', None) in UNSUPPORTED_STATUS_TYPES:
+            return
         # cached_orgid exists only for users authenticated
         # successfully in past 24 hours
         username = request.data.get('username') or request.query_params.get('username')
@@ -320,9 +325,7 @@ class AccountingView(ListCreateAPIView):
         processing the response without generating warnings
         """
         data = request.data.copy()
-        # Accounting-On and Accounting-Off are not implemented and
-        # hence  ignored right now - may be implemented in the future
-        if data.get('status_type', None) in ['Accounting-On', 'Accounting-Off']:
+        if data.get('status_type', None) in UNSUPPORTED_STATUS_TYPES:
             return Response(None)
         # Create or Update
         try:

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -1096,6 +1096,33 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertEqual(response.data, None)
         self.assertEqual(RadiusAccounting.objects.count(), 0)
 
+    def test_accounting_when_nas_using_pfsense_started(self):
+        data = {
+            "status_type": "Accounting-On",
+            "session_id": "",
+            "unique_id": "bc184fc97e3d58a9583d2ca5bc2ee210",
+            "username": "",
+            "realm": "",
+            "nas_ip_address": "10.0.0.14",
+            "nas_port_id": "",
+            "nas_port_type": "",
+            "session_time": "",
+            "authentication": "RADIUS",
+            "input_octets": "",
+            "output_octets": "",
+            "called_station_id": "00:00:45:a7:73:e3:owisp_gw1",
+            "calling_station_id": "",
+            "terminate_cause": "",
+            "service_type": "Login-User",
+            "framed_protocol": "",
+            "framed_ip_address": "",
+        }
+        response = self.client.post(
+            self._acct_url, data=json.dumps(data), content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, None)
+
     def test_get_authorize_view(self):
         url = f'{reverse("radius:authorize")}{self.token_querystring}'
         r = self.client.get(url, HTTP_ACCEPT='text/html')


### PR DESCRIPTION
Earlier, forbidden was showing because username is missing while doing
FreeradiusApiAuthentication. Fixed this behaviour by skipping check for
username when status type is unsupported.

Fixes #298