### PR TITLE
[change!] Renamed URL of radius batch endpoint #302

### DIFF
--- a/docs/source/user/api.rst
+++ b/docs/source/user/api.rst
@@ -657,7 +657,7 @@ This API endpoint allows to use the features described in
 
 .. code-block:: text
 
-    /api/v1/radiusbatch/
+    /api/v1/radius/batch/
 
 .. note::
   This API endpoint allows to use the features described in :doc:`/user/importing_users`

--- a/openwisp_radius/api/urls.py
+++ b/openwisp_radius/api/urls.py
@@ -67,9 +67,9 @@ def get_api_urls(api_views=None):
                 api_views.change_phone_number,
                 name='phone_number_change',
             ),
-            path('radiusbatch/', api_views.batch, name='batch'),
+            path('radius/batch/', api_views.batch, name='batch'),
             path(
-                'radius/organization/<slug:slug>/radiusbatch/<uuid:pk>/pdf/',
+                'radius/organization/<slug:slug>/batch/<uuid:pk>/pdf/',
                 api_views.download_rad_batch_pdf,
                 name='download_rad_batch_pdf',
             ),


### PR DESCRIPTION
#302 
changed the endpoint /api/v1/radiusbatch and
 /api/v1/radius/organization/{slug}/radiusbatch/{id}/pdf
and updated the radiusbatch documentation in API Documentation