### PR TITLE
[fix] Fixed KeyError in RegisterSerializer.validate_cross_org_registration

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -425,12 +425,15 @@ class RegisterSerializer(
         ):
             raise error
 
+        def has_key(key):
+            return key in error_dict and key in data
+
         user_lookup = Q()
-        if 'username' in error_dict:
+        if has_key('username'):
             user_lookup |= Q(username=data['username'])
-        if 'email' in error_dict:
+        if has_key('email'):
             user_lookup |= Q(email=data['email'])
-        if 'phone_number' in error_dict:
+        if has_key('phone_number'):
             user_lookup |= Q(phone_number=data['phone_number'])
         try:
             user = User.objects.get(user_lookup)

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -75,6 +75,20 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         self.assertEqual(r.status_code, 400)
         self.assertIn('phone_number', r.data)
 
+        with self.subTest('phone_number missing entirely'):
+            r = self.client.post(
+                url,
+                {
+                    'username': self._test_email,
+                    'email': self._test_email,
+                    'password1': 'password',
+                    'password2': 'password',
+                    'method': 'mobile_phone',
+                },
+            )
+            self.assertEqual(r.status_code, 400)
+            self.assertIn('phone_number', r.data)
+
     def test_register_400_duplicate_phone_number(self):
         self._register_user()
         url = reverse('radius:rest_register', args=[self.default_org.slug])


### PR DESCRIPTION
This method took for granted the presence of specific keys in the sent data,
but that can break, this patch fixes this issue by checking for the presence
of the key not only in error_dict but also in data.