### PR TITLE
[fix] Added error handling for exceptions raised by telnetlib #316

### DIFF
--- a/openwisp_radius/management/commands/base/convert_called_station_id.py
+++ b/openwisp_radius/management/commands/base/convert_called_station_id.py
@@ -44,13 +44,18 @@ class BaseConvertCalledStationIdCommand(BaseCommand):
         except ConnectionRefusedError:
             logger.error(
                 'Unable to establish telnet connection to '
-                f'{host} on {port}. '
+                f'{host} on {port}. Skipping!'
+            )
+            return {}
+        except (OSError, TimeoutError) as error:
+            logger.error(
+                f'Error encountered while connecting to {host}:{port}: {error}. '
                 'Skipping!'
             )
             return {}
-        except OSError as error:
-            logger.error(
-                f'Encountered error connection to {host}:{port}: ' f'{error}. Skipping!'
+        except Exception:
+            logger.exception(
+                f'Error encountered while connecting to {host}:{port}. Skipping!'
             )
             return {}
         try:

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -257,8 +257,19 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             ):
                 call_command('convert_called_station_id')
                 mocked_logger.assert_called_once_with(
-                    'Encountered error connection to 127.0.0.1:7505: '
+                    'Error encountered while connecting to 127.0.0.1:7505: '
                     '[Errno 113] No route to host. Skipping!'
+                )
+
+        with self.subTest('Test telnet connection timed out'):
+            with patch('logging.Logger.exception') as mocked_logger, patch(
+                'openwisp_radius.management.commands.base.convert_called_station_id'
+                '.BaseConvertCalledStationIdCommand._get_raw_management_info',
+                side_effect=EOFError,
+            ):
+                call_command('convert_called_station_id')
+                mocked_logger.assert_called_once_with(
+                    'Error encountered while connecting to 127.0.0.1:7505. ' 'Skipping!'
                 )
 
         with self.subTest('Test telnet password incorrect'):


### PR DESCRIPTION
The "convert_called_station_id" command uses telnetlib library to
connect to OpenVPN management interface. This operation can
throw numerous errors and exceptions due to underlying libraries.
Hence, handling for generic exception class is added to esure that
the operation continues even when a connection errors out.
All error encountered while performing this operation are logged.

Closes #316