### PR TITLE
[fix] Convert called station ID operates only on open sessions #317

### DIFF
--- a/docs/source/user/management_commands.rst
+++ b/docs/source/user/management_commands.rst
@@ -167,3 +167,11 @@ replacing session's ``unique_id`` in the following command:
     If you encounter ``ParseError`` for datetime data, you can set the datetime format
     of the parser using `OPENWISP_RADIUS_OPENVPN_DATETIME_FORMAT <./settings.html#openwisp-radius-openvpn-datetime-format>`_
     setting.
+
+.. note::
+
+    ``convert_called_station_id`` command will only operate on open RADIUS sessions,
+    i.e. the "stop_time" field is None.
+
+    But if you are converting a single RADIUS session, it will operate on
+    it even if the session is closed.

--- a/openwisp_radius/management/commands/base/convert_called_station_id.py
+++ b/openwisp_radius/management/commands/base/convert_called_station_id.py
@@ -126,6 +126,7 @@ class BaseConvertCalledStationIdCommand(BaseCommand):
                 qs = RadiusAccounting.objects.filter(
                     organization__slug=org_slug,
                     called_station_id__in=config['unconverted_ids'],
+                    stop_time__isnull=True,
                 ).iterator()
             for radius_session in qs:
                 try:

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -354,3 +354,15 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             radius_acc2.refresh_from_db()
             self.assertEqual(radius_acc1.called_station_id, 'CC-CC-CC-CC-CC-0C')
             self.assertNotEqual(radius_acc2.called_station_id, 'CC-CC-CC-CC-CC-0C')
+
+        with self.subTest('Test stop time is None'):
+            rad_options = options.copy()
+            rad_options['unique_id'] = '121'
+            rad_options['stop_time'] = '2017-06-10 11:50:00'
+            radius_acc = self._create_radius_accounting(**rad_options)
+            with self._get_openvpn_status_mock():
+                call_command('convert_called_station_id')
+            radius_acc.refresh_from_db()
+            self.assertEqual(
+                radius_acc.called_station_id, rad_options['called_station_id']
+            )


### PR DESCRIPTION
"convert_called_station_id" command will only operate on open session,
i.e. the "stop_time" field is None.

It will operate on the session passed using  "unique_id" argument
even if the session is closed.

Closes #317 