### PR TITLE
[fix] Handled SAML authentication by a logged in user

### DIFF
--- a/openwisp_radius/saml/views.py
+++ b/openwisp_radius/saml/views.py
@@ -3,6 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 import swapper
 from django.conf import settings
+from django.contrib.auth import logout
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import get_object_or_404, render
 from djangosaml2.views import (
@@ -107,4 +108,8 @@ class LoginView(OrganizationSamlMixin, BaseLoginView):
             logger.error(str(error))
             return render(request, 'djangosaml2/login_error.html')
 
+        # Log out the user before initiating the SAML flow
+        # to avoid past sessions to get in the way and break the flow
+        if request.user.is_authenticated:
+            logout(request)
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
Bug:
If for some reason a user stays authenticated even after logging out,
and then tries to authenticate via SAML, they will get redirected to the
"RelayState" query parameter present in the URL. This might not play
well with frontend applications like openwisp-wifi-login-pages.

Fix:
Logout the user before proceeding with SAML login flow