### PR TITLE
[deps] Fix setup.py failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'django-private-storage~=3.0',
         'celery~=5.2.3',
         'django-ipware~=3.0.0',
+        'setuptools~=59.1.1',
     ],
     extras_require={
         # TODO: change this when next point version of djangosaml2 is released


### PR DESCRIPTION
On `Ubuntu 21.10 amd64`, `sudo python3 setup.py develop` fails with this message.
```
error: setuptools 52.0.0 is installed but setuptools<59.7.0,>=59.1.1 is required by {'celery'}
```
Signed-off-by: Masashi Honma <masashi.honma@gmail.com>