### PR TITLE
[change] Adds check for valid prefix in batch creation #365

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -901,7 +901,8 @@ class AbstractRadiusBatch(OrgMixin, TimeStampedEditableModel):
                     raise ValidationError(
                         {
                             'prefix': _(
-                                'This value may contain only letters, numbers, and @/./+/-/_ characters.'
+                                'This value may contain only \
+                        letters, numbers, and @/./+/-/_ characters.'
                             )
                         },
                         code='invalid',

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -3,6 +3,7 @@ import ipaddress
 import json
 import logging
 import os
+import string
 from base64 import encodebytes
 from datetime import timedelta
 from hashlib import md5, sha1
@@ -893,6 +894,18 @@ class AbstractRadiusBatch(OrgMixin, TimeStampedEditableModel):
             raise ValidationError(
                 {'prefix': _('This field cannot be blank.')}, code='invalid'
             )
+        if self.strategy == 'prefix' and self.prefix:
+            valid_chars = string.ascii_letters + string.digits + "@.+-_"
+            for char in self.prefix:
+                if char not in valid_chars:
+                    raise ValidationError(
+                        {
+                            'prefix': _(
+                                'This value may contain only letters, numbers, and @/./+/-/_ characters.'
+                            )
+                        },
+                        code='invalid',
+                    )
         if (
             self.strategy == 'csv'
             and self.prefix


### PR DESCRIPTION
@atb00ker This commit adds a check such that the prefix in a batch user creation only accepts letters, numbers and the special characters @/./+/-/_