### PR TITLE
[fix] Fixed cross organization registration for multiple user accounts

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -458,15 +458,15 @@ class RegisterSerializer(
             return key in error_dict and key in data
 
         user_lookup = Q()
-        if has_key('username'):
-            user_lookup |= Q(username=data['username'])
-        if has_key('email'):
-            user_lookup |= Q(email=data['email'])
+        # Phone number is given preference over email and username.
         if has_key('phone_number'):
             user_lookup |= Q(phone_number=data['phone_number'])
-        try:
-            user = User.objects.get(user_lookup)
-        except User.DoesNotExist:
+        if has_key('email'):
+            user_lookup |= Q(email=data['email'])
+        if has_key('username'):
+            user_lookup |= Q(username=data['username'])
+        user = User.objects.filter(user_lookup).first()
+        if not user:
             # Error is not related to cross organization registration
             raise error
         if OrganizationUser.objects.filter(

--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -461,10 +461,10 @@ class RegisterSerializer(
         # Phone number is given preference over email and username.
         if has_key('phone_number'):
             user_lookup |= Q(phone_number=data['phone_number'])
-        if has_key('email'):
-            user_lookup |= Q(email=data['email'])
         if has_key('username'):
             user_lookup |= Q(username=data['username'])
+        if has_key('email'):
+            user_lookup |= Q(email=data['email'])
         users = User.objects.filter(user_lookup).values_list('id', flat=True)
         if not users:
             # Error is not related to cross organization registration

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -249,6 +249,29 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             self.assertEqual(User.objects.count(), init_user_count + 1)
             self.assertEqual(OrganizationUser.objects.count(), org_user_count + 1)
 
+        with self.subTest('Test multiple existing accounts'):
+            # Create a second user that has different email and username
+            test_user2 = self._create_user(
+                username='test_user2@example.com',
+                email='test_user2@example.com',
+            )
+            OrganizationUser.objects.create(
+                user=test_user2, organization=self.default_org
+            )
+            # User combination of username, email and phone number
+            # of both users that were previously created.
+            params = {
+                'username': test_user2.username,
+                'email': test_user2.email,
+                'phone_number': '+33675579231',
+                'password1': 'password',
+                'password2': 'password',
+            }
+            response = self.client.post(url, data=params)
+            self.assertEqual(response.status_code, 409)
+            self.assertEqual(User.objects.count(), init_user_count + 2)
+            self.assertEqual(OrganizationUser.objects.count(), org_user_count + 2)
+
         self.default_org.radius_settings.sms_verification = False
         self.default_org.radius_settings.save()
 

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -275,10 +275,10 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             self.assertEqual(OrganizationUser.objects.count(), org_user_count + 2)
 
         with self.subTest('Test user already registered with organization'):
-            # Make test_user2 organization user for org2.
+            # Make test_user2 member of org2.
             # The query will give preference to phone_number which
             # will return HTTP 409 response. But since the other
-            # information belongs to user which already has account
+            # information belongs to an user which already has account
             # with this organization, it should return HTTP 400.
             OrganizationUser.objects.create(user=test_user2, organization=org2)
             # User combination of username, email and phone number
@@ -291,7 +291,6 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
                 'password2': 'password',
             }
             response = self.client.post(url, data=params)
-            print(response.data)
             self.assertEqual(response.status_code, 400)
             self.assertEqual(User.objects.count(), init_user_count + 2)
             self.assertEqual(OrganizationUser.objects.count(), org_user_count + 3)


### PR DESCRIPTION
Cross organization registration validated failed when regiration
data belonged to two different users.

Now, it handles this case by selecting the first object from the
query.