### PR TITLE
[fix] Fixed handling of interim-updates for closed sessions #322

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -453,9 +453,11 @@ class AccountingView(ListCreateAPIView):
             return Response(None)
 
     def _is_interim_update_corner_case(self, error, data):
-        # Handles "Interim-Updates" for RadiusAccounting sessions
-        # that are closed by OpenWISP when user logs into
-        # another organization.
+        """
+        Handles "Interim-Updates" for RadiusAccounting sessions
+        that are closed by OpenWISP when user logs into
+        another organization.
+        """
         unique_id_errors = error.detail.get('unique_id', [])
         if len(unique_id_errors) == 1:
             error_detail = unique_id_errors.pop()

--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -13,7 +13,12 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.utils import swagger_auto_schema
 from ipware import get_client_ip
 from rest_framework.authentication import BaseAuthentication
-from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated, ParseError
+from rest_framework.exceptions import (
+    AuthenticationFailed,
+    NotAuthenticated,
+    ParseError,
+    ValidationError,
+)
 from rest_framework.generics import CreateAPIView, GenericAPIView, ListCreateAPIView
 from rest_framework.response import Response
 
@@ -428,7 +433,26 @@ class AccountingView(ListCreateAPIView):
             instance = self.get_queryset().get(unique_id=data.get('unique_id'))
         except RadiusAccounting.DoesNotExist:
             serializer = self.get_serializer(data=data)
-            serializer.is_valid(raise_exception=True)
+            try:
+                serializer.is_valid(raise_exception=True)
+            except ValidationError as error:
+                # Handles "Interim-Updates" for RadiusAccounting sessions
+                # that are closed by OpenWISP when user logs into
+                # another organization.
+                unique_id_errors = error.detail.get('unique_id', [])
+                if len(unique_id_errors) == 1:
+                    error_detail = unique_id_errors.pop()
+                    if (
+                        str(error_detail)
+                        == 'accounting with this accounting unique ID already exists.'
+                        and error_detail.code == 'unique'
+                    ):
+                        rad = RadiusAccounting.objects.only(
+                            'unique_id', 'organization_id'
+                        ).get(unique_id=data.get('unique_id'))
+                        if rad.organization_id != request.auth:
+                            return Response(None)
+                raise error
             acct_data = self._data_to_acct_model(serializer.validated_data.copy())
             serializer.create(acct_data)
             headers = self.get_success_headers(serializer.data)

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -1084,6 +1084,7 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             content_type='application/json',
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, None)
 
     def test_accounting_list_200(self):
         data1 = self.acct_post_data

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -1043,6 +1043,48 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             f'Request payload: {data}'
         )
 
+    @freeze_time(START_DATE)
+    @mock.patch('logging.Logger.warn')
+    def test_accounting_interim_update_openwisp_closed_session(self, mocked_logger):
+        org2 = self._create_org(name='org2', slug='org2')
+        org2.radius_settings = OrganizationRadiusSettings.objects.create(
+            organization=org2
+        )
+        org2.save()
+        self.assertEqual(RadiusAccounting.objects.count(), 0)
+
+        # Create RadiusAccounting object with "default" organization
+        data = self.acct_post_data
+        data['status_type'] = 'Interim-Update'
+        data = self._get_accounting_params(**data)
+        response = self.post_json(data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(RadiusAccounting.objects.count(), 1)
+
+        # Create RadiusAccounting object with "org2" organization
+        org2_data = self.acct_post_data
+        org2_data['status_type'] = 'Interim-Update'
+        org2_data['unique_id'] = '42'
+        org2_data = self._get_accounting_params(**org2_data)
+        response = self.client.post(
+            self._acct_url,
+            data=json.dumps(org2_data),
+            HTTP_AUTHORIZATION=f'Bearer {org2.pk} {org2.radius_settings.token}',
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(RadiusAccounting.objects.count(), 2)
+
+        # Send Interim-Update request for "default" organization
+        # with Authorization header containing "org2" credentials.
+        response = self.client.post(
+            self._acct_url,
+            data=json.dumps(data),
+            HTTP_AUTHORIZATION=f'Bearer {org2.pk} {org2.radius_settings.token}',
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_accounting_list_200(self):
         data1 = self.acct_post_data
         data1.update(


### PR DESCRIPTION
Added handling of "Interim-Updates" for RadiusAccounting sessions
that are closed by OpenWISP when user logs into another organization.

Fixes #322