### PR TITLE
[change] Updated accounting start email to indicate duration #379

### DIFF
--- a/docs/source/developer/setup.rst
+++ b/docs/source/developer/setup.rst
@@ -91,6 +91,7 @@ modules listed ``INSTALLED_APPS``:
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
+        'django.contrib.humanize',
         # openwisp admin theme
         'openwisp_utils.admin_theme',
         # all-auth

--- a/openwisp_radius/locale/de/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/de/LC_MESSAGES/django.po
@@ -136,6 +136,10 @@ msgstr "Eine neue Session für Ihren Account wird gestartet:"
 msgid "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below."
 msgstr "Um die Dauer und den Datenverbrauch Ihrer Session zu überwachen oder um Ihre Session in jedem Moment zu beenden, klicken Sie auf den folgenden Link."
 
+#: openwisp_radius/templates/radius_accounting_start.html:5
+msgid "Note: this link is valid only for %(sesame_max_age)s"
+msgstr "Hinweis: dieser Link ist nur %(sesame_max_age)s gültig"
+
 #: openwisp_radius/tasks.py:75
 msgid "Manage Session"
 msgstr "Session verwalten"

--- a/openwisp_radius/locale/fur/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/fur/LC_MESSAGES/django.po
@@ -133,6 +133,10 @@ msgstr "E je stade inviade une gnove session pal to account:"
 msgid "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below."
 msgstr "Tu puedis monitorâ il consum di timp e trafic de tô session o sierâ la session in cualsisedi moment clicant su chest link."
 
+#: openwisp_radius/templates/radius_accounting_start.html:5
+msgid "Note: this link is valid only for %(sesame_max_age)s"
+msgstr "Nota: questo link è valido solo per %(sesame_max_age)s"
+
 #: openwisp_radius/tasks.py:75
 msgid "Manage Session"
 msgstr "Gjestìs session"

--- a/openwisp_radius/locale/it/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/it/LC_MESSAGES/django.po
@@ -133,6 +133,10 @@ msgstr "È stata avviata una nuova sessione per il tuo account:"
 msgid "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below."
 msgstr "Puoi monitorare il consumo di tempo e traffico della tua sessione o terminare la sessione in qualsiasi momento cliccando sul collegamento seguente."
 
+#: openwisp_radius/templates/radius_accounting_start.html:6
+msgid "Note: this link is valid only for %(sesame_max_age)s"
+msgstr "Nota: questo link è scadrá %(sesame_max_age)s"
+
 #: openwisp_radius/tasks.py:75
 msgid "Manage Session"
 msgstr "Gestisci sessione"

--- a/openwisp_radius/locale/ru/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/ru/LC_MESSAGES/django.po
@@ -128,6 +128,10 @@ msgstr "Для вашей учетной записи началася нову�
 msgid "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below."
 msgstr "Вы можете отслеживать время и потребление трафика вашей сессии или завершить сессию в любое время, нажав на следующую ссылку."
 
+#: openwisp_radius/templates/radius_accounting_start.html:5
+msgid "Note: this link is valid only for %(sesame_max_age)s"
+msgstr "Примечание: эта ссылка действительна только в течение %(sesame_max_age)s"
+
 #: openwisp_radius/tasks.py:75
 msgid "Manage Session"
 msgstr "Управление сессией"

--- a/openwisp_radius/locale/sl/LC_MESSAGES/django.po
+++ b/openwisp_radius/locale/sl/LC_MESSAGES/django.po
@@ -133,6 +133,10 @@ msgstr "Začela se je nova seja vašega računa:"
 msgid "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below."
 msgstr "Trajanje seje in prenos podatkov lahko spremljate ali kadar koli zaključite s klikom na naslednjo povezavo."
 
+#: openwisp_radius/templates/radius_accounting_start.html:5
+msgid "Note: this link is valid only for %(sesame_max_age)s"
+msgstr "Opomba: ta povezava velja samo %(sesame_max_age)s"
+
 #: openwisp_radius/tasks.py:75
 msgid "Manage Session"
 msgstr "Upravljanje seje"

--- a/openwisp_radius/templates/radius_accounting_start.html
+++ b/openwisp_radius/templates/radius_accounting_start.html
@@ -1,5 +1,7 @@
 {% load i18n %}{% load l10n %}
+{% load humanize %}
 <div class="msg">
 <p>{% trans "A new session has been started for your account:" %} {{ user.get_username }}.</p>
 <p>{% trans "You can review your session to find out how much time and/or traffic has been used or you can terminate the session at any time by clicking on the button below." %}</p>
+{% if sesame_max_age %}<p><b>{% blocktrans with sesame_max_age|naturaltime as sesame_max_age %}Note: this link is valid only for {{sesame_max_age}}{% endblocktrans %}.</b></p>{% endif %}
 </div>

--- a/openwisp_radius/tests/test_tasks.py
+++ b/openwisp_radius/tests/test_tasks.py
@@ -6,6 +6,7 @@ from celery.contrib.testing.worker import start_worker
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail, management
+from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from openwisp_radius import tasks
@@ -115,7 +116,6 @@ class TestTasks(FileMixin, BaseTestCase):
         organization = self._get_org()
         accounting_data['organization'] = organization.id
         total_mails = len(mail.outbox)
-
         with self.subTest(
             'do not send mail if login_url does not exists for the organization'
         ):
@@ -173,9 +173,28 @@ class TestTasks(FileMixin, BaseTestCase):
                 ' and/or traffic has been used or you can terminate the session',
                 ' '.join(email.alternatives[0][0].split()),
             )
+            self.assertNotIn(
+                'Note: this link is valid only for an hour from now',
+                ' '.join(email.alternatives[0][0].split()),
+            )
             translation_activate.assert_called_with(user.language)
 
         translation_activate.reset_mock()
+
+        with override_settings(SESAME_MAX_AGE=2 * 60 * 60):
+            with self.subTest(
+                'it should check expiration text is present when SESAME_MAX_AGE is set'
+            ):
+                tasks.send_login_email.delay(accounting_data)
+                self.assertEqual(len(mail.outbox), total_mails + 1)
+                email = mail.outbox.pop()
+                self.assertIn(
+                    'Note: this link is valid only for an hour from now',
+                    ' '.join(email.alternatives[0][0].split()),
+                )
+                translation_activate.assert_called_with(user.language)
+
+            translation_activate.reset_mock()
 
         with self.subTest('it should send mail in user language preference'):
             user.language = 'it'

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
     # openwisp admin theme
     'openwisp_utils.admin_theme',
     'openwisp_users.accounts',


### PR DESCRIPTION
Updated radius_accounting_start email to indicate duration of validity of link
only if SESAME_MAX_AGE is not None.

Closes #379

Signed-off-by: Aryaman <aryamanz29@gmail.com>

[chores] Adjustments to accounting start email sesame text #379

Related to #379

Co-authored-by: Federico Capoano <f.capoano@openwisp.io>