### PR TITLE
[fix] Delete unverified users: ignore exclude_methods if not present

### DIFF
--- a/openwisp_radius/management/commands/base/delete_unverified_users.py
+++ b/openwisp_radius/management/commands/base/delete_unverified_users.py
@@ -29,22 +29,32 @@ class BaseDeleteUnverifiedUsersCommand(BaseCommand):
 
     def handle(self, *args, **options):
         days = now() - timedelta(days=int(options['older_than_days']))
-        exclude_methods = str(options['exclude_methods']).split(',')
-        for user in (
-            User.objects.filter(
-                date_joined__lt=days,
-                registered_user__isnull=False,
-                registered_user__is_verified=False,
-                is_staff=False,
-            )
-            .exclude(registered_user__method__in=exclude_methods)
-            .iterator()
-        ):
+        exclude_methods = str(options['exclude_methods'])
+        if exclude_methods:
+            exclude_methods = exclude_methods.split(',')
+
+        qs = User.objects.filter(
+            date_joined__lt=days,
+            registered_user__isnull=False,
+            registered_user__is_verified=False,
+            is_staff=False,
+        )
+        if exclude_methods:
+            qs = qs.exclude(registered_user__method__in=exclude_methods)
+
+        for user in qs.iterator():
             if not RadiusAccounting.objects.filter(username=user.username).exists():
                 user.delete()
 
-        self.stdout.write(
+        output = (
             'Deleted unverified accounts older than '
-            f'{options["older_than_days"]} day(s) with registration method '
-            f'other than {options["exclude_methods"]}'
+            f'{options["older_than_days"]} day(s)'
         )
+        if exclude_methods:
+            output += (
+                ', excluding users having registered with '
+                f'the following methods: {options["exclude_methods"]}'
+            )
+        output += '.'
+
+        self.stdout.write(output)


### PR DESCRIPTION
The code (queryset and output massage) didn't take into account the possibility of exclude_methods not being passed, I fixed that.