### PR TITLE
[misc] Added tests and fixed bug in allowed mobile prefix API validation

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -91,12 +91,9 @@ class AllowedMobilePrefixMixin(object):
         Verifies if a phone number's international prefix is allowed
         """
         country_code = phonenumbers.parse(str(phone_number)).country_code
-        allowed_global_prefixes = set(app_settings.ALLOWED_MOBILE_PREFIXES)
-        allowed_org_prefixes = set(mobile_prefixes)
-        allowed_prefixes = allowed_global_prefixes.union(allowed_org_prefixes)
-        if not allowed_prefixes:
+        if not mobile_prefixes:
             return True
-        return ('+' + str(country_code)) in allowed_prefixes
+        return '+' + str(country_code) in mobile_prefixes
 
 
 class AuthorizeSerializer(serializers.Serializer):

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -172,7 +172,6 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertIn('username', response.data)
         self.assertIn('email', response.data)
 
-    @mock.patch('openwisp_radius.settings.ALLOWED_MOBILE_PREFIXES', ['+33'])
     def test_register_duplicate_different_org(self):
         self.default_org.radius_settings.sms_verification = True
         self.default_org.radius_settings.save()
@@ -183,7 +182,7 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         params = {
             'username': self._test_email,
             'email': self._test_email,
-            'phone_number': '+33675579231',
+            'phone_number': '+393664255803',
             'password1': 'password',
             'password2': 'password',
         }
@@ -200,7 +199,7 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
 
         with self.subTest('Test existing email'):
             options = params.copy()
-            options['phone_number'] = '+33675579231'
+            options['phone_number'] = '+393664255803'
             options['username'] = 'test2'
 
             response = self.client.post(url, data=options)
@@ -265,7 +264,7 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             params = {
                 'username': test_user2.username,
                 'email': test_user2.email,
-                'phone_number': '+33675579231',
+                'phone_number': '+393664255803',
                 'password1': 'password',
                 'password2': 'password',
             }
@@ -286,7 +285,7 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             params = {
                 'username': test_user2.username,
                 'email': test_user2.email,
-                'phone_number': '+33675579231',
+                'phone_number': '+393664255803',
                 'password1': 'password',
                 'password2': 'password',
             }
@@ -714,13 +713,13 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertEqual(response.status_code, 401)
 
     @capture_any_output()
-    @mock.patch('openwisp_users.settings.AUTH_BACKEND_AUTO_PREFIXES', ['+33'])
+    @mock.patch('openwisp_users.settings.AUTH_BACKEND_AUTO_PREFIXES', ['+39'])
     def test_api_password_reset(self):
         test_user = User.objects.create_user(
             username='test_name',
             password='test_password',
             email='test@email.com',
-            phone_number='+33675579231',
+            phone_number='+393664255803',
         )
         self._create_org_user(organization=self.default_org, user=test_user)
         mail_count = len(mail.outbox)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,5 @@ freezegun
 django-extensions
 openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/master/
 pylinkvalidator
+lxml~=4.8.0
+cssselect~=1.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ sphinx_rtd_theme~=0.5.0
 sphinx~=4.2.0
 freezegun
 django-extensions
-openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/master/
+openwisp-utils[qa]~=1.0.0
 pylinkvalidator
 lxml~=4.8.0
 cssselect~=1.1.0

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -14,6 +14,7 @@ SECRET_KEY = '&a@f(0@lrl%606smticbu20=pvribdvubk5=gjti8&n1y%bi&4'
 
 ALLOWED_HOSTS = []
 OPENWISP_RADIUS_FREERADIUS_ALLOWED_HOSTS = ['127.0.0.1']
+OPENWISP_RADIUS_ALLOWED_MOBILE_PREFIXES = ['+44', '+39', '+237', '+595']
 
 INSTALLED_APPS = [
     'django.contrib.auth',


### PR DESCRIPTION
Fixed bug in allowed mobile prefix implementation:
The implementation was joining the globally allowed prefixes
and the prefixes allowed at org level, with the result
that disabling a prefix at org level was not possible.

Added admin tests for default values of fallback fields #46.

Bound openwisp-utils in requirements-tests.txt.