### PR TITLE
[Fix] Replace filter_class with filterset_class

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -405,7 +405,7 @@ class AccountingView(ListCreateAPIView):
     serializer_class = RadiusAccountingSerializer
     pagination_class = AccountingViewPagination
     filter_backends = (DjangoFilterBackend,)
-    filter_class = AccountingFilter
+    filterset_class = AccountingFilter
 
     def get_queryset(self):
         return super().get_queryset().filter(organization_id=self.request.auth)

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -420,7 +420,7 @@ class UserAccountingView(ThrottledAPIMixin, DispatchOrgMixin, ListAPIView):
     serializer_class = RadiusAccountingSerializer
     pagination_class = AccountingViewPagination
     filter_backends = (DjangoFilterBackend,)
-    filter_class = UserAccountingFilter
+    filterset_class = UserAccountingFilter
     queryset = RadiusAccounting.objects.all().order_by('-start_time')
 
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
In django-filter==22.1 recent release support for `filter_class` was removed.