### PR TITLE
[fix] Use storage backend method for deleting RadiusBatch.csvfile

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -995,9 +995,7 @@ class AbstractRadiusBatch(OrgMixin, TimeStampedEditableModel):
 
     def _remove_files(self):
         if self.csvfile:
-            path = self.csvfile.path
-            if os.path.isfile(path):
-                os.remove(path)
+            self.csvfile.storage.delete(self.csvfile.name)
 
 
 class AbstractRadiusToken(OrgMixin, TimeStampedEditableModel, models.Model):


### PR DESCRIPTION
The previous implementation used the "os" module for deleting resisdual
csv files. This causes issues when the project uses a file storage backend
other than based on file system.