### PR TITLE
[fix] Added error handling in RadiusBatch admin change view

### DIFF
--- a/openwisp_radius/admin.py
+++ b/openwisp_radius/admin.py
@@ -421,6 +421,9 @@ class RadiusBatchAdmin(MultitenantAdminMixin, TimeStampedEditableAdmin):
         extra_context = extra_context or {}
         radbatch = self.get_object(request, object_id)
         if radbatch is None:
+            # This is an internal Django method that redirects the
+            # user to the admin index page with a message that points
+            # out that the requested object does not exist.
             return self._get_obj_does_not_exist_redirect(
                 request, self.model._meta, object_id
             )

--- a/openwisp_radius/admin.py
+++ b/openwisp_radius/admin.py
@@ -419,7 +419,11 @@ class RadiusBatchAdmin(MultitenantAdminMixin, TimeStampedEditableAdmin):
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         extra_context = extra_context or {}
-        radbatch = RadiusBatch.objects.get(pk=object_id)
+        radbatch = self.get_object(request, object_id)
+        if radbatch is None:
+            return self._get_obj_does_not_exist_redirect(
+                request, self.model._meta, object_id
+            )
         if radbatch.strategy == 'prefix':
             batch_pdf_api_url = reverse(
                 'radius:download_rad_batch_pdf',

--- a/openwisp_radius/tests/test_admin.py
+++ b/openwisp_radius/tests/test_admin.py
@@ -990,6 +990,22 @@ class TestAdmin(
             administrator=True,
         )
 
+    def test_non_existing_radiusbatch_change_view(self):
+        id = '00000000-0000-0000-0000-0000000000000'
+        response = self.client.post(
+            reverse(f'admin:{self.app_label}_radiusbatch_change', args=[id]),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            (
+                f'Batch user creation with ID “{id}” doesn’t exist.'
+                ' Perhaps it was deleted?'
+            ),
+            html=True,
+        )
+
     def test_radius_usergroup_queryset(self):
         data = self._create_multitenancy_test_env(usergroup=True)
         self._test_multitenant_admin(


### PR DESCRIPTION
Bug:
Accessing admin change view of a non-existent RadiusBatch object
resulted in Server Error 500 because the "DoesNotExist"
conditioned was not handled.