### PR TITLE
[change] Improved cleanup stale session command #426

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -531,6 +531,7 @@ class AbstractRadiusAccounting(OrgMixin, models.Model):
             session.session_time = (now() - session.start_time).total_seconds()
             session.stop_time = now()
             session.update_time = session.stop_time
+            session.terminate_cause = 'Session Timeout'
             session.save()
 
 

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.mail import send_mail
 from django.db import models
-from django.db.models import ProtectedError
+from django.db.models import ProtectedError, Q
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
@@ -514,6 +514,24 @@ class AbstractRadiusAccounting(OrgMixin, models.Model):
 
     def __str__(self):
         return self.unique_id
+
+    @classmethod
+    def close_stale_sessions(cls, days):
+        older_than = timezone.now() - timedelta(days=days)
+        # If the "update_time" is recent, then the session is not closed
+        # even when the "start_time" is older than the specified time.
+        # The "start_time" of a session is only checked when the
+        # "update_time" is not set.
+        sessions = cls.objects.filter(
+            Q(update_time__lt=older_than)
+            | (Q(update_time=None) & Q(start_time__lt=older_than))
+        )
+        for session in sessions:
+            # calculate seconds in between two dates
+            session.session_time = (now() - session.start_time).total_seconds()
+            session.stop_time = now()
+            session.update_time = session.stop_time
+            session.save()
 
 
 class AbstractNas(OrgMixin, TimeStampedEditableModel):

--- a/openwisp_radius/management/commands/base/cleanup_stale_radacct.py
+++ b/openwisp_radius/management/commands/base/cleanup_stale_radacct.py
@@ -1,7 +1,4 @@
-from datetime import timedelta
-
 from django.core.management import BaseCommand
-from django.utils.timezone import now
 
 from ....utils import load_model
 
@@ -15,14 +12,7 @@ class BaseCleanupRadacctCommand(BaseCommand):
         parser.add_argument('number_of_days', type=int, nargs='?', default=15)
 
     def handle(self, *args, **options):
-        days = now() - timedelta(days=options['number_of_days'])
-        sessions = RadiusAccounting.objects.filter(start_time__lt=days, stop_time=None)
-        for session in sessions:
-            # calculate seconds in between two dates
-            session.session_time = (now() - session.start_time).total_seconds()
-            session.stop_time = now()
-            session.update_time = session.stop_time
-            session.save()
+        RadiusAccounting.close_stale_sessions(days=options['number_of_days'])
         self.stdout.write(
             f'Closed active sessions older than {options["number_of_days"]} days'
         )

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -40,6 +40,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             self.assertNotEqual(session.stop_time, None)
             self.assertNotEqual(session.session_time, None)
             self.assertEqual(session.update_time, session.stop_time)
+            self.assertEqual(session.terminate_cause, 'Session Timeout')
 
         with self.subTest(
             'Test start_time older than specified time but update_time is recent'
@@ -54,6 +55,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             self.assertEqual(session.stop_time, None)
             self.assertEqual(session.session_time, None)
             self.assertEqual(session.update_time, update_time)
+            self.assertEqual(session.terminate_cause, None)
 
         with self.subTest('Test start_time and update_time older than specified time'):
             options['unique_id'] = '119'
@@ -65,6 +67,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
             self.assertNotEqual(session.stop_time, None)
             self.assertNotEqual(session.session_time, None)
             self.assertEqual(session.update_time, session.stop_time)
+            self.assertEqual(session.terminate_cause, 'Session Timeout')
 
     @capture_any_output()
     def test_delete_old_postauth_command(self):


### PR DESCRIPTION
- Added "RadiusAccounting.close_stale_sessions" class method for
  closing stale sessions
- The method takes into account the "update_time" time of the
  session
- If the "update_time" is recent, then the session is not closed
  even when the "start_time" is older than the specified time.
  The "start_time" of a session is only checked when the
  "update_time" is not set.

Closes #426