### PR TITLE
[fix] Fixed RadiusAccounting.close_stale_sessions

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -523,8 +523,11 @@ class AbstractRadiusAccounting(OrgMixin, models.Model):
         # The "start_time" of a session is only checked when the
         # "update_time" is not set.
         sessions = cls.objects.filter(
-            Q(update_time__lt=older_than)
-            | (Q(update_time=None) & Q(start_time__lt=older_than))
+            Q(stop_time__isnull=True)
+            & (
+                Q(update_time__lt=older_than)
+                | (Q(update_time=None) & Q(start_time__lt=older_than))
+            )
         )
         for session in sessions:
             # calculate seconds in between two dates


### PR DESCRIPTION
Bug:
RadiusAccounting.close_stale_sessions was updating all session instead of only open sessions.

Fix:
Fixed the query in RadiusAccounting.close_stale_sessions and added an automated test.