### PR TITLE
[fix] Honor DISPOSABLE_RADIUS_USER_TOKEN in accounting stop API view

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -152,7 +152,13 @@ class RadiusAccountingSerializer(serializers.ModelSerializer):
         write_only=True, required=True, choices=STATUS_TYPE_CHOICES
     )
 
-    def _disable_token_auth(self, user):
+    def _disable_radius_token_auth(self, user):
+        """
+        Disables radius token auth capability unless
+        OPENWISP_RADIUS_DISPOSABLE_RADIUS_USER_TOKEN is False
+        """
+        if not app_settings.DISPOSABLE_RADIUS_USER_TOKEN:
+            return
         try:
             radius_token = RadiusToken.objects.get(user__username=user)
         except RadiusToken.DoesNotExist:
@@ -198,8 +204,7 @@ class RadiusAccountingSerializer(serializers.ModelSerializer):
         if status_type == 'Stop':
             data['update_time'] = time
             data['stop_time'] = time
-            # disable radius_token auth capability
-            self._disable_token_auth(data['username'])
+            self._disable_radius_token_auth(data['username'])
         return data
 
     def create(self, validated_data):

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -956,6 +956,23 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         radtoken.refresh_from_db()
         self.assertFalse(radtoken.can_auth)
 
+    @mock.patch.object(
+        app_settings,
+        'DISPOSABLE_RADIUS_USER_TOKEN',
+        False,
+    )
+    def test_user_auth_token_not_disabled_on_stop(self):
+        self._get_org_user()
+        radtoken = self._create_radius_token(can_auth=True)
+        # Send Accounting stop request
+        data = self.acct_post_data
+        data.update(username='tester', status_type='Stop')
+        data = self._get_accounting_params(**data)
+        response = self.post_json(data)
+        self.assertEqual(response.status_code, 201)
+        radtoken.refresh_from_db()
+        self.assertTrue(radtoken.can_auth)
+
     @freeze_time(START_DATE)
     def test_user_auth_token_org_accounting_stop(self):
         self._get_org_user()


### PR DESCRIPTION
The accounting stop REST API operation was not taking into account the OPENWISP_RADIUS_DISPOSABLE_RADIUS_USER_TOKEN setting when disabling the auth capability of the radius token.