### PR TITLE
[fix] Fixed RadiusCheck/RadiusReply empty org field raises 500 error …

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -234,12 +234,12 @@ class AttributeValidationMixin(object):
 
 class UserAttributeValidationMixin(AttributeValidationMixin):
     def _get_validation_queryset_kwargs(self):
+        kwargs = dict(user=self.user, attribute=self.attribute)
+        org = getattr(self, 'organization', None)
         # only add `organization` key if it exists
-        if getattr(self, 'organization_id'):
-            return dict(
-                organization=self.organization, user=self.user, attribute=self.attribute
-            )
-        return dict(user=self.user, attribute=self.attribute)
+        if org:
+            kwargs['organization'] = org
+        return kwargs
 
     def _get_error_message(self):
         return _(
@@ -260,10 +260,7 @@ class GroupAttributeValidationMixin(AttributeValidationMixin):
 
 
 class AbstractRadiusCheck(
-    OrgMixin,
-    AutoUsernameMixin,
-    UserAttributeValidationMixin,
-    TimeStampedEditableModel,
+    OrgMixin, AutoUsernameMixin, UserAttributeValidationMixin, TimeStampedEditableModel
 ):
     username = models.CharField(
         verbose_name=_('username'),
@@ -301,10 +298,7 @@ class AbstractRadiusCheck(
 
 
 class AbstractRadiusReply(
-    OrgMixin,
-    AutoUsernameMixin,
-    UserAttributeValidationMixin,
-    TimeStampedEditableModel,
+    OrgMixin, AutoUsernameMixin, UserAttributeValidationMixin, TimeStampedEditableModel
 ):
     username = models.CharField(
         verbose_name=_('username'),

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -256,8 +256,28 @@ class GroupAttributeValidationMixin(AttributeValidationMixin):
         ) % {'object_name': self._object_name}
 
 
+class OrganizationValitationMixin(object):
+    def _check_organization_field_empty(self):
+        """
+        checks if the `RadiusCheck` or `RadiusReply`
+        `organization` field is empty or not
+        """
+        return not getattr(self, 'organization_id') and (
+            getattr(self, 'user_id') or getattr(self, 'username')
+        )
+
+    def clean(self):
+        if self._check_organization_field_empty():
+            return
+        return super().clean()
+
+
 class AbstractRadiusCheck(
-    OrgMixin, AutoUsernameMixin, UserAttributeValidationMixin, TimeStampedEditableModel
+    OrgMixin,
+    AutoUsernameMixin,
+    OrganizationValitationMixin,
+    UserAttributeValidationMixin,
+    TimeStampedEditableModel,
 ):
     username = models.CharField(
         verbose_name=_('username'),
@@ -295,7 +315,11 @@ class AbstractRadiusCheck(
 
 
 class AbstractRadiusReply(
-    OrgMixin, AutoUsernameMixin, UserAttributeValidationMixin, TimeStampedEditableModel
+    OrgMixin,
+    AutoUsernameMixin,
+    OrganizationValitationMixin,
+    UserAttributeValidationMixin,
+    TimeStampedEditableModel,
 ):
     username = models.CharField(
         verbose_name=_('username'),

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -234,9 +234,12 @@ class AttributeValidationMixin(object):
 
 class UserAttributeValidationMixin(AttributeValidationMixin):
     def _get_validation_queryset_kwargs(self):
-        return dict(
-            organization=self.organization, user=self.user, attribute=self.attribute
-        )
+        # only add `organization` key if it exists
+        if getattr(self, 'organization_id'):
+            return dict(
+                organization=self.organization, user=self.user, attribute=self.attribute
+            )
+        return dict(user=self.user, attribute=self.attribute)
 
     def _get_error_message(self):
         return _(
@@ -256,26 +259,9 @@ class GroupAttributeValidationMixin(AttributeValidationMixin):
         ) % {'object_name': self._object_name}
 
 
-class OrganizationValitationMixin(object):
-    def _check_organization_field_empty(self):
-        """
-        checks if the `RadiusCheck` or `RadiusReply`
-        `organization` field is empty or not
-        """
-        return not getattr(self, 'organization_id') and (
-            getattr(self, 'user_id') or getattr(self, 'username')
-        )
-
-    def clean(self):
-        if self._check_organization_field_empty():
-            return
-        return super().clean()
-
-
 class AbstractRadiusCheck(
     OrgMixin,
     AutoUsernameMixin,
-    OrganizationValitationMixin,
     UserAttributeValidationMixin,
     TimeStampedEditableModel,
 ):
@@ -317,7 +303,6 @@ class AbstractRadiusCheck(
 class AbstractRadiusReply(
     OrgMixin,
     AutoUsernameMixin,
-    OrganizationValitationMixin,
     UserAttributeValidationMixin,
     TimeStampedEditableModel,
 ):

--- a/openwisp_radius/tests/test_admin.py
+++ b/openwisp_radius/tests/test_admin.py
@@ -107,6 +107,20 @@ class TestAdmin(
         self.assertContains(response, 'ok')
         self.assertNotContains(response, 'errors')
 
+    def test_radiusreply_add_when_organization_field_empty(self):
+        data = dict(
+            username='bob', attribute='Cleartext-Password', op=':=', value='passbob'
+        )
+        url = reverse(f'admin:{self.app_label}_radiusreply_add')
+        self.assertEqual(RadiusReply.objects.count(), 0)
+        # try to post data without an organisation field
+        response = self.client.post(url, data)
+        # response should contain errors
+        self.assertContains(response, 'errors')
+        self.assertContains(response, 'This field is required.')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(RadiusReply.objects.count(), 0)
+
     def test_radiusgroupreply_change(self):
         options = dict(
             groupname='students', attribute='Cleartext-Password', op=':=', value='PPP'
@@ -199,6 +213,19 @@ class TestAdmin(
         response = self.client.post(url, data, follow=True)
         self.assertContains(response, 'ok')
         self.assertNotContains(response, 'errors')
+
+    def test_radiuscheck_add_when_organization_field_empty(self):
+        data = self._RADCHECK_ENTRY.copy()
+        data['mode'] = 'custom'
+        url = reverse(f'admin:{self.app_label}_radiuscheck_add')
+        self.assertEqual(RadiusCheck.objects.count(), 0)
+        # try to post data without an organisation field
+        response = self.client.post(url, data)
+        # response should contain errors
+        self.assertContains(response, 'errors')
+        self.assertContains(response, 'This field is required.')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(RadiusCheck.objects.count(), 0)
 
     def test_radiusbatch_change(self):
         obj = self._create_radius_batch(

--- a/openwisp_radius/tests/test_models.py
+++ b/openwisp_radius/tests/test_models.py
@@ -307,6 +307,22 @@ class TestRadiusCheck(BaseTestCase):
         else:
             self.fail('ValidationError not raised')
 
+    def test_radius_check_empty_organization_field(self):
+        org1 = self._create_org(**{'name': 'org1', 'slug': 'org1'})
+        u = get_user_model().objects.create(
+            username='test', email='test@test.org', password='test'
+        )
+        self._create_org_user(organization=org1, user=u)
+        with self.assertRaises(ValidationError) as err:
+            self._create_radius_check(
+                user=u,
+                op=':=',
+                attribute='Max-Daily-Session',
+                value='3200',
+                organization=None,
+            )
+        self.assertIn('This field cannot be null.', err.exception.messages)
+
 
 class TestRadiusReply(BaseTestCase):
     def test_string_representation(self):
@@ -415,6 +431,22 @@ class TestRadiusReply(BaseTestCase):
             )
         else:
             self.fail('ValidationError not raised')
+
+    def test_radius_reply_empty_organization_field(self):
+        org1 = self._create_org(**{'name': 'org1', 'slug': 'org1'})
+        u = get_user_model().objects.create(
+            username='test', email='test@test.org', password='test'
+        )
+        self._create_org_user(organization=org1, user=u)
+        with self.assertRaises(ValidationError) as err:
+            self._create_radius_reply(
+                user=u,
+                attribute='Reply-Message',
+                op=':=',
+                value='Login failed',
+                organization=None,
+            )
+        self.assertIn('This field cannot be null.', err.exception.messages)
 
 
 class TestRadiusPostAuth(BaseTestCase):

--- a/openwisp_radius/tests/test_models.py
+++ b/openwisp_radius/tests/test_models.py
@@ -307,22 +307,6 @@ class TestRadiusCheck(BaseTestCase):
         else:
             self.fail('ValidationError not raised')
 
-    def test_radius_check_empty_organization_field(self):
-        org1 = self._create_org(**{'name': 'org1', 'slug': 'org1'})
-        u = get_user_model().objects.create(
-            username='test', email='test@test.org', password='test'
-        )
-        self._create_org_user(organization=org1, user=u)
-        with self.assertRaises(ValidationError) as err:
-            self._create_radius_check(
-                user=u,
-                op=':=',
-                attribute='Max-Daily-Session',
-                value='3200',
-                organization=None,
-            )
-        self.assertIn('This field cannot be null.', err.exception.messages)
-
 
 class TestRadiusReply(BaseTestCase):
     def test_string_representation(self):
@@ -431,22 +415,6 @@ class TestRadiusReply(BaseTestCase):
             )
         else:
             self.fail('ValidationError not raised')
-
-    def test_radius_reply_empty_organization_field(self):
-        org1 = self._create_org(**{'name': 'org1', 'slug': 'org1'})
-        u = get_user_model().objects.create(
-            username='test', email='test@test.org', password='test'
-        )
-        self._create_org_user(organization=org1, user=u)
-        with self.assertRaises(ValidationError) as err:
-            self._create_radius_reply(
-                user=u,
-                attribute='Reply-Message',
-                op=':=',
-                value='Login failed',
-                organization=None,
-            )
-        self.assertIn('This field cannot be null.', err.exception.messages)
 
 
 class TestRadiusPostAuth(BaseTestCase):


### PR DESCRIPTION
- Fixed `RadiusCheck/RadiusReply` empty `org field` raises **500 error**.

![Screenshot from 2023-01-03 16-31-19](https://user-images.githubusercontent.com/56113566/210344844-bc604263-c498-4942-87cf-59431d41e828.png)

    
 Fixes #464