### PR TITLE
[deps] Added support for Django 4.1 and Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,8 @@ jobs:
           - "3.10"
         django-version:
           - django~=3.2.0
-          - django~=4.0.0
-        include:
-          - django-version: django~=3.2.0
-            python-version: 3.7
+          - django~=4.1.0
+          - django~=4.2.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install openwisp-radius
         run: |
           pip install -e .[saml,openvpn_status]
-          pip install "openwisp-utils[rest,celery] @ https://github.com/openwisp/openwisp-utils/tarball/fix-drf-yasg-deps"
+          pip install "openwisp-utils[rest,celery] @ https://github.com/openwisp/openwisp-utils/tarball/master"
           pip install ${{ matrix.django-version }}
 
       - name: QA checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install openwisp-radius
         run: |
           pip install -e .[saml,openvpn_status]
+          pip install "openwisp-utils[rest,celery] @ https://github.com/openwisp/openwisp-utils/tarball/fix-drf-yasg-deps"
           pip install ${{ matrix.django-version }}
 
       - name: QA checks

--- a/openwisp_radius/__init__.py
+++ b/openwisp_radius/__init__.py
@@ -16,6 +16,3 @@ def get_version():
                 rev = 0
             version = '%s%s%s' % (version, VERSION[3][0:1], rev)
     return version
-
-
-default_app_config = 'openwisp_radius.apps.OpenwispRadiusConfig'

--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -169,7 +169,7 @@ class RadiusAccountingSerializer(serializers.ModelSerializer):
 
     def is_valid(self, raise_exception=False):
         try:
-            return super().is_valid(raise_exception)
+            return super().is_valid(raise_exception=raise_exception)
         except serializers.ValidationError as error:
             request = self.context.get('request', None)
             if request:

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -265,7 +265,7 @@ class ObtainAuthTokenView(
     UserDetailsUpdaterMixin,
 ):
     throttle_scope = 'obtain_auth_token'
-    serializer_class = rest_auth_settings.TokenSerializer
+    serializer_class = rest_auth_settings.api_settings.TOKEN_SERIALIZER
     auth_serializer_class = AuthTokenSerializer
     authentication_classes = [SesameAuthentication]
 
@@ -383,7 +383,7 @@ class ValidateAuthTokenView(
                     )
                 response = RadiusUserSerializer(user).data
                 context = {'view': self, 'request': request}
-                token_data = rest_auth_settings.TokenSerializer(
+                token_data = rest_auth_settings.api_settings.TOKEN_SERIALIZER(
                     token, context=context
                 ).data
                 token_data['auth_token'] = token_data.pop('key')

--- a/openwisp_radius/apps.py
+++ b/openwisp_radius/apps.py
@@ -203,3 +203,8 @@ class OpenwispRadiusConfig(ApiAppConfig):
             position=70,
             config={'label': _('RADIUS'), 'items': items, 'icon': 'ow-radius'},
         )
+
+
+del ApiAppConfig
+del AccountConfig
+del SocialAccountConfig

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -6,6 +6,9 @@ from unittest import mock
 import swapper
 from allauth.account.forms import default_token_generator
 from allauth.account.utils import user_pk_to_url_str
+from dj_rest_auth.tests.utils import (
+    override_api_settings as override_dj_rest_auth_settings,
+)
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -477,7 +480,7 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
 
     if (sys.version_info.major, sys.version_info.minor) > (3, 6):
 
-        @override_settings(REST_USE_JWT=True)
+        @override_dj_rest_auth_settings(USE_JWT=True)
         def test_registration_with_jwt(self):
             user_count = User.objects.all().count()
             url = reverse('radius:rest_register', args=[self.default_org.slug])
@@ -491,8 +494,8 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
                 },
             )
             self.assertEqual(r.status_code, 201)
-            self.assertIn('access_token', r.data)
-            self.assertIn('refresh_token', r.data)
+            self.assertIn('access', r.data)
+            self.assertIn('refresh', r.data)
             self.assertEqual(User.objects.all().count(), user_count + 1)
 
     def test_api_batch_add_users(self):

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -220,11 +219,7 @@ class TestPhoneToken(BaseTestCase):
         )
         radius_settings.save()
         token = self._create_token()
-        if sys.version_info < (3, 8):
-            # TODO: Remove when dropping support for Python 3.7
-            sms_body = sms_message_mock.call_args[1]['body']
-        else:
-            sms_body = sms_message_mock.call_args.kwargs['body']
+        sms_body = sms_message_mock.call_args.kwargs['body']
         self.assertEqual(
             sms_body,
             radius_settings.sms_message.format(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,7 @@
 responses
 djangorestframework-simplejwt
 django-cors-headers>=2.5.2
-redis~=3.5.0
 packaging
-sphinx~=4.2.0
 openwisp-sphinx-theme~=1.0.0
 freezegun
 django-extensions

--- a/setup.py
+++ b/setup.py
@@ -35,22 +35,23 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'django>=3.0,<=4.1.0',
         (
             'openwisp-users '
             '@ https://github.com/openwisp/openwisp-users/tarball/'
             'master'
         ),
-        'openwisp-utils[rest,celery] @ '
-        'https://github.com/openwisp/openwisp-utils/tarball/master',
+        (
+            'openwisp-utils[rest,celery] @ '
+            'https://github.com/openwisp/openwisp-utils/tarball/master'
+        ),
         'passlib~=1.7.1',
         'djangorestframework-link-header-pagination~=0.1.1',
-        'weasyprint>=43,<53',
-        'dj-rest-auth~=2.1.6',
+        'weasyprint~=59.0',
+        'dj-rest-auth~=4.0.1',
         'django-sendsms~=0.5.0',
         'jsonfield~=3.1.0',
-        'django-private-storage~=3.0',
-        'django-ipware~=3.0.0',
+        'django-private-storage~=3.1.0',
+        'django-ipware~=5.0.0',
         'pyrad~=2.4',
     ],
     extras_require={

--- a/tests/openwisp2/sample_radius/__init__.py
+++ b/tests/openwisp2/sample_radius/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'openwisp2.sample_radius.apps.SampleOpenwispRadiusConfig'

--- a/tests/openwisp2/sample_radius/apps.py
+++ b/tests/openwisp2/sample_radius/apps.py
@@ -17,3 +17,6 @@ class SampleOpenwispRadiusConfig(OpenwispRadiusConfig):
             dispatch_uid='send_email_on_new_accounting',
         )
         return super().connect_signals()
+
+
+del OpenwispRadiusConfig

--- a/tests/openwisp2/sample_users/__init__.py
+++ b/tests/openwisp2/sample_users/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'openwisp2.sample_users.apps.SampleUsersConfig'

--- a/tests/openwisp2/sample_users/apps.py
+++ b/tests/openwisp2/sample_users/apps.py
@@ -4,3 +4,6 @@ from openwisp_users.apps import OpenwispUsersConfig
 class SampleUsersConfig(OpenwispUsersConfig):
     name = 'openwisp2.sample_users'
     label = 'sample_users'
+
+
+del OpenwispUsersConfig

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -268,12 +268,10 @@ CELERY_BEAT_SCHEDULE = {
 SENDSMS_BACKEND = 'sendsms.backends.console.SmsBackend'
 OPENWISP_RADIUS_EXTRA_NAS_TYPES = (('cisco', 'Cisco Router'),)
 
-REST_AUTH_SERIALIZERS = {
-    'PASSWORD_RESET_SERIALIZER': 'openwisp_radius.api.serializers.PasswordResetSerializer'
-}
-
-REST_AUTH_REGISTER_SERIALIZERS = {
-    'REGISTER_SERIALIZER': 'openwisp_radius.api.serializers.RegisterSerializer'
+REST_AUTH = {
+    'SESSION_LOGIN': False,
+    'PASSWORD_RESET_SERIALIZER': 'openwisp_radius.api.serializers.PasswordResetSerializer',
+    'REGISTER_SERIALIZER': 'openwisp_radius.api.serializers.RegisterSerializer',
 }
 
 ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = 'email_confirmation_success'


### PR DESCRIPTION
- Dropped support for Django 4.0
- Dropped support for Python 3.7
- Bumped weasyprint~=59.0
- Bumped dj-rest-auth~=4.0.1

**Important**: dj-rest-auth>3 changed configuration settings. It is recommended to review your Django project settings while upgrading.

**Blockers**
- [x] https://github.com/openwisp/openwisp-utils/pull/347