### PR TITLE
Bug Fix: Different types of phone numbers are allowed, but only mobile types should

### DIFF
--- a/docs/source/user/settings.rst
+++ b/docs/source/user/settings.rst
@@ -416,6 +416,17 @@ or Cameroon (``+237``).
     which have :ref:`enabled the SMS verification option
     <openwisp_radius_sms_verification_enabled>`.
 
+``OPENWISP_RADIUS_ALLOW_FIXED_LINE_OR_MOBILE``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Default**: ``False``
+
+OpenWISP RADIUS only allow using mobile phone numbers for user registration.
+This can cause issues in regions where fixed line and mobile phone numbers
+ uses the same pattern (e.g. USA). Setting the value to ``True``
+would make phone number type checking less strict.
+
+
 ``OPENWISP_RADIUS_SMS_COOLDOWN``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/user/settings.rst
+++ b/docs/source/user/settings.rst
@@ -426,7 +426,6 @@ This can cause issues in regions where fixed line and mobile phone numbers
  uses the same pattern (e.g. USA). Setting the value to ``True``
 would make phone number type checking less strict.
 
-
 ``OPENWISP_RADIUS_SMS_COOLDOWN``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openwisp_radius/settings.py
+++ b/openwisp_radius/settings.py
@@ -95,6 +95,7 @@ SMS_COOLDOWN = get_settings_value('SMS_COOLDOWN', 30)
 # default is high because openwisp-wifi-login-pages results always as 1 IP
 SMS_TOKEN_MAX_IP_DAILY = get_settings_value('SMS_TOKEN_MAX_IP_DAILY', 999)
 ALLOWED_MOBILE_PREFIXES = get_settings_value('ALLOWED_MOBILE_PREFIXES', [])
+ALLOW_FIXED_LINE_OR_MOBILE = get_settings_value('ALLOW_FIXED_LINE_OR_MOBILE', False)
 REGISTRATION_API_ENABLED = get_settings_value('REGISTRATION_API_ENABLED', True)
 NEEDS_IDENTITY_VERIFICATION = get_settings_value('NEEDS_IDENTITY_VERIFICATION', False)
 SMS_MESSAGE_TEMPLATE = get_settings_value(


### PR DESCRIPTION
I changed the code to check whether phone_number provided is a Mobile number and raise expception if not. (#484 )
Below is the function code that I have altered. 

```
 def validate_phone_number(self, phone_number):
        org = self.context['view'].organization
        if get_organization_radius_settings(org, 'sms_verification'):
            if phonenumbers.phonenumberutil.number_type(phone_number) != 1:
                raise serializers.ValidationError(_('Landline numbers can\'t be used to send SMS.'))
            if not phone_number:
                raise serializers.ValidationError(_('This field is required.'))
            mobile_prefixes = org.radius_settings.allowed_mobile_prefixes_list
            if not self.is_prefix_allowed(phone_number, mobile_prefixes):
                raise serializers.ValidationError(
                    _('This international mobile prefix is not allowed.')
                )
            if User.objects.filter(phone_number=phone_number).exists():
                raise serializers.ValidationError(
                    _('A user is already registered with this phone number.')
                )
        else:
            # Phone number should not be stored if sms verification is disabled
            phone_number = None
        return phone_number
```

---------
Closes #484 

Edited by @pandafy 