### PR TITLE
[fix] Changed the command to delete_old_radiusbatch_users #496

### DIFF
--- a/docs/source/developer/setup.rst
+++ b/docs/source/developer/setup.rst
@@ -261,7 +261,7 @@ Add and modify the following lines accordingly:
     # This command deletes users that have expired (and should have
     # been deactivated by deactivate_expired_users) for more than
     # 18 months (which is the default duration)
-    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py delete_old_users
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py delete_old_radiusbatch_users
 
 Be sure to replace ``<virtualenv_path>`` with the absolute path to the Python
 virtual environment.

--- a/docs/source/user/management_commands.rst
+++ b/docs/source/user/management_commands.rst
@@ -75,7 +75,7 @@ This command deactivates expired user accounts which were created temporarily
 
     ./manage.py deactivate_expired_users
 
-``delete_old_users``
+``delete_old_radiusbatch_users``
 --------------------
 
 This command deletes users that have expired (and should have been deactivated by
@@ -83,7 +83,7 @@ This command deletes users that have expired (and should have been deactivated b
 
 .. code-block:: shell
 
-    ./manage.py delete_old_users --older-than-months <duration_in_months>
+    ./manage.py delete_old_radiusbatch_users --older-than-months <duration_in_months>
 
 Note that the default duration is set to 18 months.
 

--- a/openwisp_radius/management/commands/base/delete_old_radiusbatch_users.py
+++ b/openwisp_radius/management/commands/base/delete_old_radiusbatch_users.py
@@ -9,7 +9,7 @@ from ....utils import load_model
 RadiusBatch = load_model('RadiusBatch')
 
 
-class BaseDeleteOldUsersCommand(BaseCommand):
+class BaseDeleteOldRadiusBatchUsersCommand(BaseCommand):
     help = 'Deactivating users added in batches which have expired'
 
     def add_arguments(self, parser):

--- a/openwisp_radius/management/commands/delete_old_radiusbatch_users.py
+++ b/openwisp_radius/management/commands/delete_old_radiusbatch_users.py
@@ -1,0 +1,5 @@
+from .base.delete_old_radiusbatch_users import BaseDeleteOldRadiusBatchUsersCommand
+
+
+class Command(BaseDeleteOldRadiusBatchUsersCommand):
+    pass

--- a/openwisp_radius/management/commands/delete_old_users.py
+++ b/openwisp_radius/management/commands/delete_old_users.py
@@ -1,5 +1,0 @@
-from .base.delete_old_users import BaseDeleteOldUsersCommand
-
-
-class Command(BaseDeleteOldUsersCommand):
-    pass

--- a/openwisp_radius/tasks.py
+++ b/openwisp_radius/tasks.py
@@ -42,8 +42,8 @@ def deactivate_expired_users():
 
 
 @shared_task
-def delete_old_users(older_than_months=12):
-    management.call_command('delete_old_users', older_than_months=older_than_months)
+def delete_old_radiusbatch_users(older_than_months=12):
+    management.call_command('delete_old_radiusbatch_users', older_than_months=older_than_months)
 
 
 @shared_task

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -153,7 +153,7 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
         self.assertEqual(get_user_model().objects.filter(is_active=True).count(), 0)
 
     @capture_stdout()
-    def test_delete_old_users_command(self):
+    def test_delete_old_radiusbatch_users(self):
         path = self._get_path('static/test_batch.csv')
         options = dict(
             organization=self.default_org.slug,

--- a/openwisp_radius/tests/test_tasks.py
+++ b/openwisp_radius/tests/test_tasks.py
@@ -67,10 +67,10 @@ class TestTasks(FileMixin, BaseTestCase):
         self.assertFalse(user.is_active)
 
     @capture_stdout()
-    def test_delete_old_users(self):
+    def test_delete_old_radiusbatch_users(self):
         self._get_expired_user_from_radius_batch()
         self.assertEqual(User.objects.all().count(), 1)
-        result = tasks.delete_old_users.delay(1)
+        result = tasks.delete_old_radiusbatch_users.delay(1)
         self.assertTrue(result.successful())
         self.assertEqual(User.objects.all().count(), 0)
 

--- a/tests/openwisp2/sample_radius/management/commands/delete_old_radiusbatch_users.py
+++ b/tests/openwisp2/sample_radius/management/commands/delete_old_radiusbatch_users.py
@@ -1,0 +1,7 @@
+from openwisp_radius.management.commands.base.delete_old_radiusbatch_users import (
+    BaseDeleteOldRadiusBatchUsersCommand,
+)
+
+
+class Command(BaseDeleteOldRadiusBatchUsersCommand):
+    pass

--- a/tests/openwisp2/sample_radius/management/commands/delete_old_users.py
+++ b/tests/openwisp2/sample_radius/management/commands/delete_old_users.py
@@ -1,7 +1,0 @@
-from openwisp_radius.management.commands.base.delete_old_users import (
-    BaseDeleteOldUsersCommand,
-)
-
-
-class Command(BaseDeleteOldUsersCommand):
-    pass

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -239,8 +239,8 @@ CELERY_BEAT_SCHEDULE = {
         'args': None,
         'relative': True,
     },
-    'delete_old_users': {
-        'task': 'openwisp_radius.tasks.delete_old_users',
+    'delete_old_radiusbatch_users': {
+        'task': 'openwisp_radius.tasks.delete_old_radiusbatch_users',
         'schedule': crontab(hour=0, minute=10),
         'args': [365],
         'relative': True,


### PR DESCRIPTION
Changes delete_old_users command to delete_old_radiusbatch_users to help users understand the purpose of the command more clearly.
Fixes #496