### PR TITLE
Update settings.py

### DIFF
--- a/openwisp_radius/settings.py
+++ b/openwisp_radius/settings.py
@@ -79,11 +79,8 @@ BATCH_PDF_TEMPLATE = get_settings_value(
 BATCH_MAIL_MESSAGE = get_settings_value(
     'BATCH_MAIL_MESSAGE', 'username: {}, password: {}'
 )
-PASSWORD_RESET_URLS = {
-    # fallback in case the specific org page is not defined
-    '__all__': 'https://{site}/{organization}/password/reset/confirm/{uid}/{token}',
-    # use the uuid because the slug can change
-}
+OPENWISP_RADIUS_PASSWORD_RESET_URLS  = {}
+
 PASSWORD_RESET_URLS.update(get_settings_value('PASSWORD_RESET_URLS', {}))
 DEFAULT_PASSWORD_RESET_URL = get_default_password_reset_url(PASSWORD_RESET_URLS)
 SMS_VERIFICATION_ENABLED = get_settings_value('SMS_VERIFICATION_ENABLED', False)


### PR DESCRIPTION
Hello,
While installing open wisp-radius in my local system, I constantly faced an issue when I gave the command to my terminal “./manage.py migrate” (following the command from the create database section which is in the installing for development section). The issue was this: “raise ImproperlyConfigured(Django.core.exceptions.ImproperlyConfigured: OPENWISP_RADIUS_PASSWORD_RESET_URLS is invalid:” So after one week of research, I found the issue and solved it. I had to change this setting. This is the PASSWORD_RESET_URLS setting from the [OpenWISP WiFi Login Pages] project, not the OPENWISP_RADIUS_PASSWORD_RESET_URLS setting from the openwisp-radius project. These are two different settings that serve different purposes. The PASSWORD_RESET_URLS setting is used to specify the URLs for a password reset for different organizations in the frontend application. The OPENWISP_RADIUS_PASSWORD_RESET_URLS setting is used to specify the URLs for a password reset for different organizations in the backend API. I need to define both settings in my project and make sure they match each other.

To fix the issue, we can do these things:
Rename the PASSWORD_RESET_URLS setting to OPENWISP_RADIUS_PASSWORD_RESET_URLS.
Change the value of all to a valid UUID of an organization, or remove this key from the dictionary. The value of all is not a valid UUID, and it will cause an error if I try to use it as a key. If we want to use the same URL for all organizations, we can either remove the setting entirely or set it to an empty dictionary. This will make OpenWISP use the default password reset URL.
As I am not very familiar with UUID, I chose the second option which is this: use the default URL for all organizations, delete the setting or set it to an empty dictionary.

After changing the code, it looks like this: OPENWISP_RADIUS_PASSWORD_RESET_URLS = {}

The reason why I renamed the PASSWORD_RESET_URLS setting to OPENWISP_RADIUS_PASSWORD_RESET_URLS is that the former is a setting from the [OpenWISP WiFi Login Pages] project, which is a separate frontend application that uses the openwisp-radius API. The latter is a setting from the openwisp-radius project, which is the backend API that handles the RADIUS authentication and authorization. These two settings should not be confused, as they have different formats and purposes. The PASSWORD_RESET_URLS setting is a dictionary that maps organization UUIDs to custom password reset URLs for the frontend application. The OPENWISP_RADIUS_PASSWORD_RESET_URLS setting is a dictionary that maps organization UUIDs to custom password reset URLs for the backend API. These URLs are used to redirect the users to the appropriate password reset page when they request a password reset via email. By renaming the setting, I avoided the ImproperlyConfigured error that was raised by the openwisp-radius project.

The reason why I changed the value of all to a valid UUID of an organization or removed this key from the dictionary, is because the value of all is not a valid UUID, and it will cause an error if I try to use it as a key. The all key is a special key that is used to specify a default value for all organizations that do not have a specific entry in the dictionary. However, the value of this key must be a valid UUID of an existing organization, otherwise, it will not work. If we want to use the same URL for all organizations, we can either remove the setting entirely or set it to an empty dictionary. This will make OpenWISP use the default password reset URL

--->
[tests/openwisp2/settings.py](https://github.com/openwisp/openwisp-radius/compare/master...d1vyanshu-kumar:openwisp-radius:master#diff-26cea5c755fb048b49985aa06de44b90bfdfe6e9165f73f08bac2197df7e61e8)

tests/openwisp2/settings.py
---->
before changes, this is the issue I faced:

https://drive.google.com/file/d/1_tbZeUbxNjxSfLl2duWWBEXR9RZ6c_cD/view?usp=sharing

after change:
https://drive.google.com/file/d/1esoXo_rWd_nNrZZ3nT2TNRYh3F2ir54o/view?usp=sharing
https://drive.google.com/file/d/1kGUfRjglauuPhi5QFOcQfW1Mrlpp2BZz/view?usp=sharing

I hope this helps Openwisp to make the user experience better. Thank you.