### PR TITLE
[fix] Fixed FreeRADIUS PostAuthView returning 500 error

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -120,7 +120,7 @@ class RadiusPostAuthSerializer(serializers.ModelSerializer):
         allow_blank=True,
         style={'input_type': 'password'},
     )
-    called_station_id = serializers.CharField(required=False, allow_blank=True)
+    called_station_id = serializers.CharField(required=False, allow_blank=True, max_length=50)
     calling_station_id = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):


### PR DESCRIPTION
Addresses the issue of PostAuthView returning HTTP status code 500, and sets a restriction on the server side so that it gives a client side error(400) instead.

Updates the PostAuthSerializer and sets the `max_length attribute` to be 50 on the `called_station_id` field, such that it returns HTTP Status Code 400 on `called_station_id` exceeding 50.

Fixes #467