### PR TITLE
[fix] Fixed 500 error when adding OrganizationUser and assigning RadiusGroup together

### DIFF
--- a/openwisp_radius/receivers.py
+++ b/openwisp_radius/receivers.py
@@ -32,20 +32,23 @@ def send_email_on_new_accounting_handler(sender, accounting_data, view, **kwargs
 
 def set_default_group_handler(sender, instance, created, **kwargs):
     if created:
-        RadiusGroup = load_model('RadiusGroup')
-        RadiusUserGroup = load_model('RadiusUserGroup')
-        queryset = RadiusGroup.objects.filter(
-            default=True, organization_id=instance.organization_id
-        )
-        if (
-            queryset.exists()
-            and not instance.user.radiususergroup_set.filter(
-                group__organization_id=instance.organization_id
-            ).exists()
-        ):
-            ug = RadiusUserGroup(user=instance.user, group=queryset.first())
-            ug.full_clean()
-            ug.save()
+        try:
+            RadiusGroup = load_model('RadiusGroup')
+            RadiusUserGroup = load_model('RadiusUserGroup')
+            queryset = RadiusGroup.objects.filter(
+                default=True, organization_id=instance.organization_id
+            )
+            if (
+                queryset.exists()
+                and not instance.user.radiususergroup_set.filter(
+                    group__organization_id=instance.organization_id
+                ).exists()
+            ):
+                ug = RadiusUserGroup(user=instance.user, group=queryset.first())
+                ug.full_clean()
+                ug.save()
+        except Exception as e:
+            logger.warning("An error occurred while setting the default group: ", e)
 
 
 def create_default_groups_handler(sender, instance, created, **kwargs):

--- a/openwisp_radius/receivers.py
+++ b/openwisp_radius/receivers.py
@@ -5,6 +5,7 @@ import logging
 
 from celery.exceptions import OperationalError
 from django.db import transaction
+from django.db.utils import IntegrityError
 from django.utils.timezone import now
 
 from openwisp_radius.tasks import send_login_email
@@ -32,23 +33,23 @@ def send_email_on_new_accounting_handler(sender, accounting_data, view, **kwargs
 
 def set_default_group_handler(sender, instance, created, **kwargs):
     if created:
-        try:
-            RadiusGroup = load_model('RadiusGroup')
-            RadiusUserGroup = load_model('RadiusUserGroup')
-            queryset = RadiusGroup.objects.filter(
-                default=True, organization_id=instance.organization_id
-            )
-            if (
-                queryset.exists()
-                and not instance.user.radiususergroup_set.filter(
-                    group__organization_id=instance.organization_id
-                ).exists()
-            ):
+        RadiusGroup = load_model('RadiusGroup')
+        RadiusUserGroup = load_model('RadiusUserGroup')
+        queryset = RadiusGroup.objects.filter(
+            default=True, organization_id=instance.organization_id
+        )
+        if (
+            queryset.exists()
+            and not instance.user.radiususergroup_set.filter(
+                group__organization_id=instance.organization_id
+            ).exists()
+        ):
+            try:
                 ug = RadiusUserGroup(user=instance.user, group=queryset.first())
                 ug.full_clean()
                 ug.save()
-        except Exception as e:
-            logger.warning("An error occurred while setting the default group: ", e)
+            except IntegrityError:
+                logger.warning("An error occurred while setting the default group")
 
 
 def create_default_groups_handler(sender, instance, created, **kwargs):

--- a/openwisp_radius/receivers.py
+++ b/openwisp_radius/receivers.py
@@ -48,8 +48,10 @@ def set_default_group_handler(sender, instance, created, **kwargs):
                 ug = RadiusUserGroup(user=instance.user, group=queryset.first())
                 ug.full_clean()
                 ug.save()
-            except IntegrityError:
-                logger.warning("An error occurred while setting the default group")
+            except IntegrityError as e:
+                logger.warning(
+                    f'An error occurred while setting the default group: {e}'
+                )
 
 
 def create_default_groups_handler(sender, instance, created, **kwargs):


### PR DESCRIPTION
In this PR, I added a try-except block to ensure that whenever a new user is created, and edited by simultaneously adding organization user with "default" org & "default-users" RadiusGroup, an error is logged as warning instead of the server raising 500 error.

Fixes #507