### PR TITLE
[change] Allow check method of counters to return None

### DIFF
--- a/docs/source/user/enforcing_limits.rst
+++ b/docs/source/user/enforcing_limits.rst
@@ -169,4 +169,6 @@ requirements are:
   the one used in the ``BaseCounter`` class;
 - the class must have a ``check`` method which doesn't need any required argument
   and returns the remaining counter value or raises ``MaxQuotaReached`` if
-  the limit has been reached and the authorization should be rejected.
+  the limit has been reached and the authorization should be rejected;
+  This method may return ``None`` if no additional RADIUS attribute
+  needs to be added to the response.

--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -323,6 +323,8 @@ class AuthorizeView(GenericAPIView, IDVerificationHelper):
                 except Exception as e:
                     logger.exception(f'Got exception "{e}" while executing {counter}')
                     continue
+                if remaining is None:
+                    continue
                 # send remaining value in RADIUS reply, if needed.
                 # This emulates the implementation of sqlcounter in freeradius
                 # which sends the reply message only if the value is smaller


### PR DESCRIPTION
This will signal that no reply should be added to the response. Useful for raising MaxQuotaReached for on custom conditions which do not necessarily have a related reply message that can be interpreted by the NAS.