### PR TITLE
Issues/523 saml auth create email address objects

### DIFF
--- a/openwisp_radius/saml/utils.py
+++ b/openwisp_radius/saml/utils.py
@@ -9,3 +9,16 @@ def get_url_or_path(url):
     if parsed_url.netloc:
         return f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}'
     return parsed_url.path
+
+
+def get_email_from_ava(ava):
+    email_keys = (
+        'email',
+        'mail',
+        'uid',
+    )
+    for key in email_keys:
+        email = ava.get(key, None)
+        if email is not None:
+            return email[0]
+    return None

--- a/openwisp_radius/saml/utils.py
+++ b/openwisp_radius/saml/utils.py
@@ -9,16 +9,3 @@ def get_url_or_path(url):
     if parsed_url.netloc:
         return f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}'
     return parsed_url.path
-
-
-def get_email_from_ava(ava):
-    email_keys = (
-        'email',
-        'mail',
-        'uid',
-    )
-    for key in email_keys:
-        email = ava.get(key, None)
-        if email is not None:
-            return email[0]
-    return None

--- a/openwisp_radius/saml/views.py
+++ b/openwisp_radius/saml/views.py
@@ -2,6 +2,7 @@ import logging
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import swapper
+from allauth.account.models import EmailAddress
 from allauth.account.utils import send_email_confirmation
 from django import forms
 from django.conf import settings
@@ -73,6 +74,22 @@ class AssertionConsumerServiceView(
         try:
             user.registered_user
         except ObjectDoesNotExist:
+            email = None
+            uid_is_email = 'email' in getattr(
+                settings, 'SAML_ATTRIBUTE_MAPPING', {}
+            ).get('uid', ())
+            if uid_is_email:
+                email = session_info['name_id'].text
+            if email is None:
+                email = session_info['ava'].get('email', [None])[0]
+            if email:
+                user.email = email
+                user.save()
+                email_address = EmailAddress.objects.create(
+                    user=user, email=email, verified=True, primary=True
+                )
+                email_address.save()
+
             registered_user = RegisteredUser(
                 user=user, method='saml', is_verified=app_settings.SAML_IS_VERIFIED
             )

--- a/openwisp_radius/saml/views.py
+++ b/openwisp_radius/saml/views.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse
 import swapper
 from allauth.account.models import EmailAddress
 from allauth.account.utils import send_email_confirmation
-from allauth.utils import valid_email_or_none
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model, logout

--- a/openwisp_radius/tests/test_saml/test_views.py
+++ b/openwisp_radius/tests/test_saml/test_views.py
@@ -7,6 +7,7 @@ from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
 from django.core import mail
+from django.core.validators import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
 from djangosaml2.tests import auth_response, conf
@@ -61,12 +62,12 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
     def _get_relay_state(self, redirect_url, org_slug):
         return f'{redirect_url}?org={org_slug}'
 
-    def _get_saml_response_for_acs_view(self, relay_state):
+    def _get_saml_response_for_acs_view(self, relay_state, uid='org_user@example.com'):
         response = self.client.get(self.login_url, {'RelayState': relay_state})
         saml2_req = saml2_from_httpredirect_request(response.url)
         session_id = get_session_id_from_saml2(saml2_req)
         self.add_outstanding_query(session_id, relay_state)
-        return auth_response(session_id, 'org_user@example.com'), relay_state
+        return auth_response(session_id, uid), relay_state
 
     def _post_successful_auth_assertions(self, query_params, org_slug):
         self.assertEqual(User.objects.count(), 1)
@@ -107,6 +108,24 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
         self.assertEqual(get_url_or_path(response.url), expected_redirect_url)
         query_params = parse_qs(urlparse(response.url).query)
         self._post_successful_auth_assertions(query_params, org_slug)
+
+    @capture_any_output()
+    def test_invalid_email_raise_validation_error(self):
+        invalid_email = 'invalid_email@example'
+        relay_state = self._get_relay_state(
+            redirect_url='https://captive-portal.example.com', org_slug='default'
+        )
+        saml_response, relay_state = self._get_saml_response_for_acs_view(
+            relay_state, uid=invalid_email
+        )
+        with self.assertRaises(ValidationError):
+            self.client.post(
+                reverse('radius:saml2_acs'),
+                {
+                    'SAMLResponse': self.b64_for_post(saml_response),
+                    'RelayState': relay_state,
+                },
+            )
 
     @capture_any_output()
     def test_relay_state_relative_path(self):

--- a/openwisp_radius/tests/test_saml/test_views.py
+++ b/openwisp_radius/tests/test_saml/test_views.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import swapper
+from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
 from django.core import mail
@@ -71,6 +72,8 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
         self.assertEqual(User.objects.count(), 1)
         user_id = self.client.session[SESSION_KEY]
         user = User.objects.get(id=user_id)
+        email = EmailAddress.objects.filter(user=user)
+        self.assertEqual(email.count(), 1)
         self.assertEqual(user.username, 'org_user@example.com')
         self.assertEqual(OrganizationUser.objects.count(), 1)
         org_user = OrganizationUser.objects.get(user_id=user_id)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #523 .


## Description of Changes

- Check if the NameID is an email and use it as the user's email.
- If NameID is not an email, check for the 'email' attribute in the SAML response.
- Create an EmailAddress object using the retrieved email.


## Screenshot

