### PR TITLE
[fix] Updated device change_form template

### DIFF
--- a/openwisp_radius/integrations/monitoring/templates/admin/config/radius-monitoring/device/change_form.html
+++ b/openwisp_radius/integrations/monitoring/templates/admin/config/radius-monitoring/device/change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/config/device/change_form.html" %}
+{% extends "admin/monitoring/device/change_form.html" %}
 {% load i18n %}
 
 {% block inline_field_sets %}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Previously, the `device change_form.html` template extended `config/device/change_form.html`. However, after merging the device deactivation feature, the inheritance order was modified. As a result, enabling the Radius integration caused the "Status" and "Charts" tabs to disappear from the device page.
