### PR TITLE
[feature] csv import add notes and user_groups field #396

### DIFF
--- a/docs/user/importing_users.rst
+++ b/docs/user/importing_users.rst
@@ -14,6 +14,7 @@ many features included in it such as:
   Usernames are generated from the email address whereas passwords are
   generated randomly and their lengths can be customized.
 - Passwords are accepted in both clear-text and hash formats from the CSV.
+- Set the RADIUS user groups that the user will belong to.
 - Send mails to users whose passwords have been generated automatically.
 
 This operation can be performed via the admin interface, with a management
@@ -28,7 +29,18 @@ The CSV shall be of the format:
 
 ::
 
+    username,password,email,firstname,lastname,notes,user_groups
+
+`user_groups` consists of one or more radius group names separated by a semicolon.
+Inserting groups that don't exist will silently fail.
+
+The previous format is also supported for backwards compatibility:
+
+::
+
     username,password,email,firstname,lastname
+
+OpenWISP will recognize the correct format automatically.
 
 Imported users with hashed passwords
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openwisp_radius/utils.py
+++ b/openwisp_radius/utils.py
@@ -150,6 +150,14 @@ def decode_byte_data(data):
     return data
 
 
+def validate_csv_batch_field_radusergroups(rugs_string):
+    if not rugs_string.strip():
+        return []
+    reader = csv.reader([rugs_string], delimiter=' ')
+    rugs = next(reader)
+    return rugs
+
+
 def validate_csvfile(csvfile):
     csv_data = csvfile.read()
 
@@ -171,6 +179,16 @@ def validate_csvfile(csvfile):
         if len(row) == 5:
             username, password, email, firstname, lastname = row
             try:
+                validate_email(email)
+            except ValidationError as error:
+                raise ValidationError(
+                    _(error_message.format(str(row_count), error.message))
+                )
+            row_count += 1
+        elif len(row) == 7:
+            username, password, email, firstname, lastname, notes, link_radius_usergroups = row
+            try:
+                validate_csv_batch_field_radusergroups(link_radius_usergroups)
                 validate_email(email)
             except ValidationError as error:
                 raise ValidationError(


### PR DESCRIPTION
Batch csv import now accepts notes and setting RADIUS groups for each user. The previous format is still accepted for backwards compatibility.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #396.

## Description of Changes

This update enhances the batch CSV import functionality to support two new fields:
- **notes**: A freeform field to allow additional information or context to be stored for each user.
- **user_groups**: Users can now be assigned one or more RADIUS groups directly via the CSV file. 
  Each group can optionally include a priority level for more granular control.

The implementation ensures backwards compatibility with the previous format by continuing to accept 
CSV files that do not include these new fields. Existing functionality is unaffected for users who 
do not use the new format.

This feature resolves issue #396, addressing the user feedback for imports.