### PR TITLE
[deps/ci] Temporarily bind to older deps to pass CI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ pylinkvalidator
 lxml~=5.3.1
 cssselect~=1.2.0
 openwisp-monitoring @ https://github.com/openwisp/openwisp-monitoring/tarball/1.2
+openwisp-controller @ https://github.com/openwisp/openwisp-controller/tarball/4881326a
 django-redis~=5.4.0
 mock-ssh-server~=0.9.1
 channels_redis~=4.2.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/1.2',
+        'openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/8b27115',
         (
             'openwisp-utils[rest,celery]'
             ' @ https://github.com/openwisp/openwisp-utils/tarball/1.2'


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Temporary measures to avoid having to merge PRs with failing builds to the upgrade we are doing for Django 5.x.