### PR TITLE
[fix] Exclude `location_id` from `radius_acc` extra_tags if missing

### DIFF
--- a/openwisp_radius/integrations/monitoring/tests/test_metrics.py
+++ b/openwisp_radius/integrations/monitoring/tests/test_metrics.py
@@ -86,6 +86,50 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
         self.assertEqual(points['traces'][0][1][-1], 1)
         self.assertEqual(points['summary'], {'mobile_phone': 1})
 
+    @patch('logging.Logger.warning')
+    def test_post_save_radiusaccounting_device_without_location(self, *args):
+        user = self._create_user()
+        reg_user = self._create_registered_user(user=user)
+        device = self._create_device()
+        options = _RADACCT.copy()
+        options.update(
+            {
+                'unique_id': '117',
+                'username': user.username,
+                'called_station_id': device.mac_address.replace('-', ':').upper(),
+                'calling_station_id': '00:00:00:00:00:00',
+                'input_octets': '8000000000',
+                'output_octets': '9000000000',
+            }
+        )
+        options['stop_time'] = options['start_time']
+        self._create_radius_accounting(**options)
+        self.assertEqual(
+            self.metric_model.objects.filter(
+                configuration='radius_acc',
+                name='RADIUS Accounting',
+                key='radius_acc',
+                object_id=str(device.id),
+                content_type=ContentType.objects.get_for_model(self.device_model),
+                extra_tags={
+                    'called_station_id': device.mac_address,
+                    'calling_station_id': sha1_hash('00:00:00:00:00:00'),
+                    'method': reg_user.method,
+                    'organization_id': str(self.default_org.id),
+                },
+            ).count(),
+            1,
+        )
+        # Deleting the device should not raise any error
+        self.device_model.objects.all().delete()
+        self.assertEqual(self.device_model.objects.count(), 0)
+        self.assertEqual(
+            self.metric_model.objects.filter(
+                key='radius_acc', object_id=str(device.id)
+            ).count(),
+            0,
+        )
+
     @patch('openwisp_radius.integrations.monitoring.tasks.post_save_radiusaccounting')
     def test_post_save_radiusaccouting_open_session(self, mocked_task):
         radius_options = _RADACCT.copy()
@@ -157,7 +201,6 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
                     extra_tags={
                         'called_station_id': device.mac_address,
                         'calling_station_id': sha1_hash('00:00:00:00:00:00'),
-                        'location_id': None,
                         'method': reg_user.method,
                         'organization_id': str(self.default_org.id),
                     },
@@ -222,7 +265,6 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
                 extra_tags={
                     'called_station_id': '11:22:33:44:55:66',
                     'calling_station_id': sha1_hash('00:00:00:00:00:00'),
-                    'location_id': None,
                     'method': reg_user.method,
                     'organization_id': str(self.default_org.id),
                 },


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Avoid including the `location_id` tag in `radius_acc` metrics when the device has no associated `DeviceLocation`.

InfluxDB does not support tags with `None` values, which causes errors when attempting to delete such metrics.

