### PR TITLE
[change] Added CSV batch download endpoint visibility on Swagger

### DIFF
--- a/openwisp_radius/private_storage/urls.py
+++ b/openwisp_radius/private_storage/urls.py
@@ -16,5 +16,13 @@ def get_private_store_urls():
             urljoin(app_settings.CSV_URL_PATH, "<path:path>"),
             views.rad_batch_csv_download_view,
             name="serve_private_file",
-        )
+        ),
+        path(
+            urljoin(
+                app_settings.CSV_URL_PATH,
+                "<slug:slug>/batch/<uuid:pk>/csv/<str:filename>/",
+            ),
+            views.RadiusBatchCsvDownloadAPIView.as_view(),
+            name="radius_organization_batch_csv_read",
+        ),
     ]

--- a/openwisp_radius/private_storage/views.py
+++ b/openwisp_radius/private_storage/views.py
@@ -12,7 +12,7 @@ class RadiusBatchCsvDownloadView(PrivateStorageDetailView):
     model = load_model("RadiusBatch")
     model_file_field = "csvfile"
     slug_field = "csvfile"
-    slug_url_kwarg = "filename"
+    slug_url_kwarg = "path"
 
     def can_access_file(self, private_file):
         user = private_file.request.user


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #373.

## Description of Changes

Integrated PrivateStorageDetailView within a DRF APIView and applied @extend_schema to enable proper Swagger documentation. This update ensures the CSV download endpoint is both functional and visible in the Swagger UI. Verified the endpoint works correctly and appears as expected in the API docs.

## Screenshot

![2025-06-09_13:21:19 84](https://github.com/user-attachments/assets/34461c3d-73bc-44cd-a77e-3e591e5837b2)
