### PR TITLE
[change] Allow overriding RADIUS reply-message on MaxQuotaReached

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -315,8 +315,9 @@ class AuthorizeView(GenericAPIView, IDVerificationHelper):
                     continue
                 # if max is reached send access rejected + reply message
                 except MaxQuotaReached as max_quota:
-                    data = self.reject_attributes.copy()
-                    data["Reply-Message"] = max_quota.reply_message
+                    data.update(self.reject_attributes.copy())
+                    if "Reply-Message" not in data:
+                        data["Reply-Message"] = max_quota.reply_message
                     return data, self.max_quota_status
                 # avoid crashing on unexpected runtime errors
                 except Exception as e:


### PR DESCRIPTION
Allows customizing the reply message when MaxQuotaReached is triggered.
Before it was hardcoded.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.