### PR TITLE
[feature] Add --number_of_hours flag to cleanup_stale_radacct

### DIFF
--- a/docs/user/management_commands.rst
+++ b/docs/user/management_commands.rst
@@ -60,6 +60,13 @@ For example:
 
     ./manage.py cleanup_stale_radacct 15
 
+If you need to clean up stale sessions more aggressively, you can use
+hours instead of days:
+
+.. code-block:: shell
+
+    ./manage.py cleanup_stale_radacct --number_of_hours=4
+
 ``deactivate_expired_users``
 ----------------------------
 

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -529,8 +529,15 @@ class AbstractRadiusAccounting(OrgMixin, models.Model):
         return self.unique_id
 
     @classmethod
-    def close_stale_sessions(cls, days):
-        older_than = timezone.now() - timedelta(days=days)
+    def close_stale_sessions(cls, days=None, hours=None):
+        if hours:
+            delta = timedelta(hours=hours)
+        elif days:
+            delta = timedelta(days=days)
+        else:
+            raise ValueError("Missing `days` or `hours`")
+        # determine limit date time
+        older_than = timezone.now() - delta
         # If the "update_time" is recent, then the session is not closed
         # even when the "start_time" is older than the specified time.
         # The "start_time" of a session is only checked when the

--- a/openwisp_radius/management/commands/base/cleanup_stale_radacct.py
+++ b/openwisp_radius/management/commands/base/cleanup_stale_radacct.py
@@ -10,9 +10,16 @@ class BaseCleanupRadacctCommand(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("number_of_days", type=int, nargs="?", default=15)
+        parser.add_argument("number_of_hours", type=int, nargs="?", default=0)
 
     def handle(self, *args, **options):
-        RadiusAccounting.close_stale_sessions(days=options["number_of_days"])
-        self.stdout.write(
-            f'Closed active sessions older than {options["number_of_days"]} days'
+        RadiusAccounting.close_stale_sessions(
+            days=options["number_of_days"],
+            # defaults to zero
+            hours=options["number_of_hours"],
         )
+        if options["number_of_hours"]:
+            time_output = f"{options['number_of_hours']} hours"
+        else:
+            time_output = f"{options['number_of_days']} days"
+        self.stdout.write(f"Closed active sessions older than {time_output}")

--- a/openwisp_radius/tasks.py
+++ b/openwisp_radius/tasks.py
@@ -28,8 +28,8 @@ def delete_old_radacct(number_of_days=365):
 
 
 @shared_task
-def cleanup_stale_radacct(number_of_days=365):
-    management.call_command("cleanup_stale_radacct", number_of_days)
+def cleanup_stale_radacct(number_of_days=365, number_of_hours=0):
+    management.call_command("cleanup_stale_radacct", number_of_days, number_of_hours)
 
 
 @shared_task


### PR DESCRIPTION
Allow cleaning up stale radacct sessions more aggressively, useful when using simultaneous-use checks.