### PR TITLE
[fix] Added error handling in task.perform_change_of_authorization

### DIFF
--- a/openwisp_radius/tasks.py
+++ b/openwisp_radius/tasks.py
@@ -153,13 +153,12 @@ def perform_change_of_authorization(user_id, old_group_id, new_group_id):
             counter = Counter(user=user, group=check.group, group_check=check)
             value = counter.check()
             return counter.reply_name, value
+        except MaxQuotaReached:
+            return check.attribute, 0
         except Exception as e:
-            # Ignore MaxQuotaReached and KeyError exceptions:
-            # - MaxQuotaReached: raised by Counter.check() when user has
-            #       reached their quota
-            # - KeyError: raised when the check attribute is not in
-            #       CHECK_ATTRIBUTE_COUNTERS_MAP
-            if not isinstance(e, (MaxQuotaReached, KeyError)):
+            # KeyError is raised when the check attribute is not in
+            # CHECK_ATTRIBUTE_COUNTERS_MAP
+            if not isinstance(e, KeyError):
                 logger.exception(
                     f"Got {e} while executing counter for {check.attribute} check."
                 )

--- a/openwisp_radius/tests/test_models.py
+++ b/openwisp_radius/tests/test_models.py
@@ -1062,8 +1062,8 @@ class TestChangeOfAuthorization(BaseTransactionTestCase):
                 )
                 mocked_radclient.assert_called_once_with(
                     {
-                        "Max-Daily-Session": "10800",
-                        "Max-Daily-Session-Traffic": "3000000000",
+                        "Max-Daily-Session": "0",
+                        "Max-Daily-Session-Traffic": "0",
                         "User-Name": "tester",
                     }
                 )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

--- 

How a user can encounter this edge case:

1. A user initially belongs to a RADIUS Group that provides unrestricted access (`power-users`).
2. The user consumes more than 1 GB of traffic.
3. The user’s RADIUS group is then downgraded to a RADIUS Group with a daily limit of 100 MB (Max-Daily-Session-Traffic).
4. When executing DailyTrafficCounter.check(),  the counter will raise MaxQuotaReached because the user has consumed more than 100 MB on the same day. 

