### PR TITLE
[fix] Error when creating RadiusGroup with inlines (#604)

### DIFF
--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -219,7 +219,7 @@ class AutoGroupnameMixin(object):
 
     def save(self, *args, **kwargs):
         self._set_groupname()
-        super().save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
 
 class AttributeValidationMixin(object):

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -200,6 +200,10 @@ class AutoUsernameMixin(object):
 
 
 class AutoGroupnameMixin(object):
+    def _set_groupname(self):
+        if self.group:
+            self.groupname = self.group.name
+
     def clean(self):
         """
         automatically sets groupname
@@ -207,19 +211,14 @@ class AutoGroupnameMixin(object):
         if self.group and not self.group.pk:
             return
         super().clean()
-        if self.group:
-            self.groupname = self.group.name
-        elif not self.groupname:
+        self._set_groupname()
+        if not self.group and not self.groupname:
             raise ValidationError(
                 {"groupname": _NOT_BLANK_MESSAGE, "group": _NOT_BLANK_MESSAGE}
             )
 
     def save(self, *args, **kwargs):
-        """
-        Ensure groupname is populated from the group relation before saving.
-        """
-        if self.group:
-            self.groupname = self.group.name
+        self._set_groupname()
         super().save(*args, **kwargs)
 
 

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -204,6 +204,8 @@ class AutoGroupnameMixin(object):
         """
         automatically sets groupname
         """
+        if self.group and not self.group.pk:
+            return
         super().clean()
         if self.group:
             self.groupname = self.group.name
@@ -211,6 +213,14 @@ class AutoGroupnameMixin(object):
             raise ValidationError(
                 {"groupname": _NOT_BLANK_MESSAGE, "group": _NOT_BLANK_MESSAGE}
             )
+
+    def save(self, *args, **kwargs):
+        """
+        Ensure groupname is populated from the group relation before saving.
+        """
+        if self.group:
+            self.groupname = self.group.name
+        super().save(*args, **kwargs)
 
 
 class AttributeValidationMixin(object):

--- a/openwisp_radius/tests/test_admin.py
+++ b/openwisp_radius/tests/test_admin.py
@@ -1494,3 +1494,57 @@ class TestAdmin(
         with self.subTest("test radius group is registered"):
             html = '<div class="mg-dropdown-label">RADIUS </div>'
             self.assertContains(response, html, html=True)
+
+
+class TestRadiusGroupAdmin(BaseTestCase):
+    def setUp(self):
+        self.organization = self._create_org()
+        self.admin = self._create_admin()
+        self.organization.add_user(self.admin, is_admin=True)
+        self.client.force_login(self.admin)
+
+    def test_add_radiusgroup_with_inline_check_succeeds(self):
+        add_url = reverse("admin:openwisp_radius_radiusgroup_add")
+
+        post_data = {
+            # Main RadiusGroup form
+            "organization": self.organization.pk,
+            "name": "test-group-with-inline",
+            "description": "A test group created with an inline check",
+            # Inline RadiusGroupCheck formset
+            "radiusgroupcheck_set-TOTAL_FORMS": "1",
+            "radiusgroupcheck_set-INITIAL_FORMS": "0",
+            "radiusgroupcheck_set-0-attribute": "Max-Daily-Session",
+            "radiusgroupcheck_set-0-op": ":=",
+            "radiusgroupcheck_set-0-value": "3600",
+            # Inline RadiusGroupReply formset
+            "radiusgroupreply_set-TOTAL_FORMS": "1",
+            "radiusgroupreply_set-INITIAL_FORMS": "0",
+            "radiusgroupreply_set-0-attribute": "Session-Timeout",
+            "radiusgroupreply_set-0-op": "=",
+            "radiusgroupreply_set-0-value": "1800",
+        }
+
+        response = self.client.post(add_url, data=post_data, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        final_group_name = f"{self.organization.slug}-test-group-with-inline"
+
+        self.assertContains(response, "The group")
+        self.assertContains(response, f"{final_group_name}</a>")
+        self.assertContains(response, "was added successfully.")
+
+        self.assertTrue(RadiusGroup.objects.filter(name=final_group_name).exists())
+        group = RadiusGroup.objects.get(name=final_group_name)
+
+        self.assertEqual(group.radiusgroupcheck_set.count(), 1)
+        check = group.radiusgroupcheck_set.first()
+        self.assertEqual(check.attribute, "Max-Daily-Session")
+        self.assertEqual(check.value, "3600")
+        self.assertEqual(check.groupname, group.name)
+
+        self.assertEqual(group.radiusgroupreply_set.count(), 1)
+        reply = group.radiusgroupreply_set.first()
+        self.assertEqual(reply.attribute, "Session-Timeout")
+        self.assertEqual(reply.value, "1800")
+        self.assertEqual(reply.groupname, group.name)


### PR DESCRIPTION
Closes #604 

The crash happened because the `clean()` method tried to validate using the parent group before that group was actually saved, which caused the ValidationError.

Fixed it by:

* Skip `clean()` validation when the parent group hasn’t been saved yet (fixes error when creating a new group).
* Add a `save()` method to ensure `groupname` is populated from the parent’s name before saving (prevents empty strings).
