### PR TITLE
[chores] Use theme color variables instead of hardcoded values #661

### DIFF
--- a/openwisp_radius/integrations/monitoring/static/radius-monitoring/css/device-change.css
+++ b/openwisp_radius/integrations/monitoring/static/radius-monitoring/css/device-change.css
@@ -10,7 +10,7 @@
   height: 4em;
 }
 #radius-session-tbody strong {
-  color: green;
+  color: var(--ow-color-success, green);
 }
 #radius-session-tbody tr td p {
   white-space: nowrap;

--- a/openwisp_radius/integrations/monitoring/static/radius-monitoring/css/device-change.css
+++ b/openwisp_radius/integrations/monitoring/static/radius-monitoring/css/device-change.css
@@ -10,7 +10,7 @@
   height: 4em;
 }
 #radius-session-tbody strong {
-  color: var(--ow-color-success, green);
+  color: var(--ow-color-success);
 }
 #radius-session-tbody tr td p {
   white-space: nowrap;

--- a/openwisp_radius/static/openwisp-radius/css/mode-switcher.css
+++ b/openwisp_radius/static/openwisp-radius/css/mode-switcher.css
@@ -6,5 +6,5 @@
 .form-row.field-user label,
 .form-row.field-username label {
   font-weight: bold;
-  color: #333;
+  color: var(--ow-color-fg-darker, #333);
 }

--- a/openwisp_radius/static/openwisp-radius/css/mode-switcher.css
+++ b/openwisp_radius/static/openwisp-radius/css/mode-switcher.css
@@ -6,5 +6,4 @@
 .form-row.field-user label,
 .form-row.field-username label {
   font-weight: bold;
-  color: var(--ow-color-fg-darker, #333);
 }

--- a/openwisp_radius/static/openwisp-radius/css/radiusbatch.css
+++ b/openwisp_radius/static/openwisp-radius/css/radiusbatch.css
@@ -2,5 +2,4 @@
 .field-prefix label,
 .field-number_of_users label {
   font-weight: bold;
-  color: var(--ow-color-black, #000);
 }

--- a/openwisp_radius/static/openwisp-radius/css/radiusbatch.css
+++ b/openwisp_radius/static/openwisp-radius/css/radiusbatch.css
@@ -2,5 +2,5 @@
 .field-prefix label,
 .field-number_of_users label {
   font-weight: bold;
-  color: #000;
+  color: var(--ow-color-black, #000);
 }

--- a/openwisp_radius/templates/openwisp-radius/prefix_pdf.html
+++ b/openwisp_radius/templates/openwisp-radius/prefix_pdf.html
@@ -10,7 +10,7 @@
         table { width: 100%; border-collapse: collapse }
         table th { font-weight: bold }
         table th, table td {
-            border: 1px solid #ccc;
+            border: 1px solid var(--ow-color-fg-medium, #ccc);
             padding: 10px;
         }
     </style>

--- a/openwisp_radius/templates/openwisp-radius/prefix_pdf.html
+++ b/openwisp_radius/templates/openwisp-radius/prefix_pdf.html
@@ -10,7 +10,7 @@
         table { width: 100%; border-collapse: collapse }
         table th { font-weight: bold }
         table th, table td {
-            border: 1px solid var(--ow-color-fg-medium, #ccc);
+            border: 1px solid #ccc;
             padding: 10px;
         }
     </style>


### PR DESCRIPTION
Replace hardcoded colors in CSS files and templates with the CSS variables introduced in openwisp-utils#516 to ensure unified theming and simplify future palette updates.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #661 .
