### PR TITLE
[fix] Removed re-registering of SocialAppAdmin

### DIFF
--- a/openwisp_radius/admin.py
+++ b/openwisp_radius/admin.py
@@ -622,7 +622,7 @@ OrganizationAdmin.inlines.append(OrganizationRadiusSettingsInline)
 # avoid cluttering the admin with too many models, leave only the
 # minimum required to configure social login and check if it's working
 if app_settings.SOCIAL_REGISTRATION_CONFIGURED:
-    from allauth.socialaccount.admin import SocialAccount, SocialApp, SocialAppAdmin
+    from allauth.socialaccount.admin import SocialAccount
 
     class SocialAccountInline(admin.StackedInline):
         model = SocialAccount
@@ -636,7 +636,6 @@ if app_settings.SOCIAL_REGISTRATION_CONFIGURED:
             return False
 
     UserAdmin.inlines += [SocialAccountInline]
-    admin.site.register(SocialApp, SocialAppAdmin)
 
 
 if app_settings.USER_ADMIN_RADIUSTOKEN_INLINE:


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.


## Description of Changes

Since openwisp-users==1.2.1, openwisp-users is responsible for registering SocialAppAdmin. Thus, re-registering the admin class here raises error.

