### PR TITLE
[fix] Preserved text -> jsonb migration for JSONField fields #722

### DIFF
--- a/openwisp_radius/migrations/0007_sms_verification.py
+++ b/openwisp_radius/migrations/0007_sms_verification.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="organizationradiussettings",
             name="sms_meta_data",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 help_text=(
                     "Additional configuration for SMS backend in JSON format"

--- a/openwisp_radius/migrations/0009_radbatch_user_credentials_field.py
+++ b/openwisp_radius/migrations/0009_radbatch_user_credentials_field.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="radiusbatch",
             name="user_credentials",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 null=True,
                 verbose_name="PDF",

--- a/tests/openwisp2/sample_radius/migrations/0002_initial_openwisp_app.py
+++ b/tests/openwisp2/sample_radius/migrations/0002_initial_openwisp_app.py
@@ -542,7 +542,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "sms_meta_data",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         help_text=(
                             "Additional configuration for SMS backend in JSON format"
@@ -694,7 +694,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "user_credentials",
-                    models.JSONField(blank=True, null=True, verbose_name="PDF"),
+                    models.TextField(blank=True, null=True, verbose_name="PDF"),
                 ),
                 (
                     "expiration_date",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #722

Please [open a new issue](https://github.com/openwisp/openwisp-radius/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Historical migrations were updated to use models.TextField instead of models.JSONField for fields originally backed by the third-party jsonfield library.

The original jsonfield.fields.JSONField inherited from TextField and stored values as PostgreSQL text. Replacing historical migration definitions with models.JSONField caused Django to interpret the migration transition as JSONField -> JSONField, resulting in a no-op migration and preventing PostgreSQL columns from being converted to jsonb.

By preserving the historical field semantics as TextField, Django can correctly detect the transition from text -> jsonb and generate the required ALTER COLUMN ... TYPE jsonb migration SQL during upgrades.


