### PR TITLE
[fix] Fixed WebSocket authorization for batch status updates

### DIFF
--- a/openwisp_radius/consumers.py
+++ b/openwisp_radius/consumers.py
@@ -1,6 +1,5 @@
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from django.core.exceptions import ObjectDoesNotExist
 
 from .utils import load_model
 
@@ -8,35 +7,27 @@ from .utils import load_model
 class RadiusBatchConsumer(AsyncJsonWebsocketConsumer):
     def _user_can_access_batch(self, user, batch_id):
         RadiusBatch = load_model("RadiusBatch")
-        # Superusers have access to everything,
+        # Superusers have access to everything
         if user.is_superuser:
             return RadiusBatch.objects.filter(pk=batch_id).exists()
-        # For non-superusers, check their managed organizations
-        try:
-            RadiusBatch.objects.filter(
-                pk=batch_id, organization__in=user.organizations_managed
-            ).exists()
-            return True
-        except ObjectDoesNotExist:
-            return False
+        # Non-superusers can only access their managed organizations
+        return RadiusBatch.objects.filter(
+            pk=batch_id, organization__in=user.organizations_managed
+        ).exists()
 
     async def connect(self):
         self.batch_id = self.scope["url_route"]["kwargs"]["batch_id"]
         self.user = self.scope["user"]
         self.group_name = f"radius_batch_{self.batch_id}"
-
         if not self.user.is_authenticated or not self.user.is_staff:
             await self.close()
             return
-
         has_permission = await sync_to_async(self._user_can_access_batch)(
             self.user, self.batch_id
         )
-
         if not has_permission:
             await self.close()
             return
-
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
 

--- a/openwisp_radius/tests/test_consumers.py
+++ b/openwisp_radius/tests/test_consumers.py
@@ -1,0 +1,84 @@
+from asgiref.sync import async_to_sync
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from django.test import TransactionTestCase, override_settings
+
+from openwisp_radius.routing import websocket_urlpatterns
+from openwisp_users.models import OrganizationUser
+
+from . import CreateRadiusObjectsMixin
+
+User = get_user_model()
+
+
+@override_settings(
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+)
+class TestRadiusBatchConsumerAuth(CreateRadiusObjectsMixin, TransactionTestCase):
+    application = URLRouter(websocket_urlpatterns)
+
+    def _connect(self, path, user):
+        communicator = WebsocketCommunicator(self.application, path)
+        communicator.scope["user"] = user
+        connected = async_to_sync(communicator.connect)()
+        return connected
+
+    def test_superuser_can_access_any_batch(self):
+        org = self._create_org(name="org", slug="org")
+        batch = self._create_radius_batch(
+            name="superuser-test",
+            strategy="prefix",
+            prefix="test-",
+            organization=org,
+            status="processing",
+        )
+        admin = self._create_admin()
+        connected = self._connect(f"/ws/radius/batch/{batch.pk}/", admin)
+        self.assertTrue(connected[0])
+
+    def test_non_staff_superuser_is_rejected(self):
+        org = self._create_org(name="org", slug="org")
+        batch = self._create_radius_batch(
+            name="non-staff-superuser-test",
+            strategy="prefix",
+            prefix="test-",
+            organization=org,
+            status="processing",
+        )
+        superuser = self._create_admin(username="superuser", is_staff=False)
+        connected = self._connect(f"/ws/radius/batch/{batch.pk}/", superuser)
+        self.assertFalse(connected[0])
+
+    def test_staff_user_managing_org_can_access(self):
+        org = self._create_org(name="org", slug="org")
+        batch = self._create_radius_batch(
+            name="manager-test",
+            strategy="prefix",
+            prefix="test-",
+            organization=org,
+            status="processing",
+        )
+        manager = self._create_administrator(organizations=[org])
+        connected = self._connect(f"/ws/radius/batch/{batch.pk}/", manager)
+        self.assertTrue(connected[0])
+
+    def test_staff_user_not_managing_org_is_rejected(self):
+        org_a = self._create_org(name="org-a", slug="org-a")
+        org_b = self._create_org(name="org-b", slug="org-b")
+        batch = self._create_radius_batch(
+            name="rejection-test",
+            strategy="prefix",
+            prefix="test-",
+            organization=org_a,
+            status="processing",
+        )
+        user = User.objects.create_user(
+            username="other-org-staff",
+            email="other-org-staff@example.com",
+            password="tester",
+            is_staff=True,
+        )
+        OrganizationUser.objects.create(organization=org_b, user=user, is_admin=True)
+        connected = self._connect(f"/ws/radius/batch/{batch.pk}/", user)
+        self.assertFalse(connected[0])


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation. N/A

## Reference to Existing Issue

Small fix, opening a dedicated issue is not needed here.

## Description of Changes

Fixes RadiusBatch WebSocket authorization by returning the organization access check result for non-superuser staff users.

Adds regression tests for allowed and rejected WebSocket connections.

## Screenshot

Not applicable.