### PR TITLE
[tests] Fixed flaky RadiusBatch expiration tests

### DIFF
--- a/openwisp_radius/tests/test_batch_add_users.py
+++ b/openwisp_radius/tests/test_batch_add_users.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.urls import reverse
-from django.utils.timezone import now
+from django.utils.timezone import localdate
 
 from ..utils import load_model
 from . import FileMixin
@@ -16,7 +16,7 @@ RadiusBatch = load_model("RadiusBatch")
 
 class TestCSVUpload(FileMixin, BaseTestCase):
     def test_users_inherit_batch_expiration_date(self):
-        expiration_date = now().date() + timedelta(days=7)
+        expiration_date = localdate() + timedelta(days=7)
         reader = [["rohith", "cleartext$password", "rohith@openwisp.com", "", ""]]
         batch = self._create_radius_batch(
             name="test",
@@ -29,8 +29,8 @@ class TestCSVUpload(FileMixin, BaseTestCase):
         self.assertEqual(user.expiration_date, expiration_date)
 
     def test_importing_users_override_expiration_date(self):
-        original_expiration_date = now().date() + timedelta(days=14)
-        batch_expiration_date = now().date() + timedelta(days=7)
+        original_expiration_date = localdate() + timedelta(days=14)
+        batch_expiration_date = localdate() + timedelta(days=7)
         existing_user = self._create_user(
             username="rohith-existing",
             email="rohith@openwisp.com",
@@ -126,7 +126,7 @@ class TestCSVUpload(FileMixin, BaseTestCase):
 
 class TestPrefixUpload(FileMixin, BaseTestCase):
     def test_users_inherit_batch_expiration_date(self):
-        expiration_date = now().date() + timedelta(days=7)
+        expiration_date = localdate() + timedelta(days=7)
         batch = self._create_radius_batch(
             name="test",
             strategy="prefix",
@@ -144,7 +144,7 @@ class TestPrefixUpload(FileMixin, BaseTestCase):
                 name="test-past-expiration",
                 strategy="prefix",
                 prefix="TestPast",
-                expiration_date=now().date() - timedelta(days=1),
+                expiration_date=localdate() - timedelta(days=1),
             )
 
         self.assertEqual(

--- a/openwisp_radius/tests/test_models.py
+++ b/openwisp_radius/tests/test_models.py
@@ -756,7 +756,7 @@ class TestRadiusBatch(BaseTestCase):
                 strategy="prefix",
                 prefix="test-prefix16",
                 name="test-past-expiration",
-                expiration_date=timezone.now().date() - timezone.timedelta(days=1),
+                expiration_date=timezone.localdate() - timezone.timedelta(days=1),
             )
         self.assertEqual(
             context_manager.exception.message_dict["expiration_date"],
@@ -791,7 +791,7 @@ class TestRadiusBatch(BaseTestCase):
             self.fail("ValidationError not raised")
 
     def test_clean_method_allows_unchanged_past_expiration_date(self):
-        expiration_date = timezone.now().date() - timezone.timedelta(days=1)
+        expiration_date = timezone.localdate() - timezone.timedelta(days=1)
         radiusbatch = RadiusBatch.objects.create(
             organization=self.default_org,
             name="test-legacy-expiration",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Small change not requiring issue.

## Description of Changes

`RadiusBatch` expiration validation uses the active local date.

The tests built dates from UTC now(). In `America/Asuncion`, yesterday could still be today shortly after midnight UTC.