### PR TITLE
[fix] Close telnet connection properly in convert_called_station_id

### DIFF
--- a/openwisp_radius/management/commands/base/convert_called_station_id.py
+++ b/openwisp_radius/management/commands/base/convert_called_station_id.py
@@ -23,7 +23,12 @@ class BaseConvertCalledStationIdCommand(BaseCommand):
     help = "Correct Called Station IDs of Radius Sessions"
 
     def _get_raw_management_info(self, host, port, password):
-        with telnetlib.Telnet(host, port, timeout=TELNET_CONNECTION_TIMEOUT) as tn:
+        # Exscript's telnetlib.Telnet is a re-implementation that does not
+        # support the context manager protocol, so a `with` statement raised
+        # a TypeError that was silently swallowed upstream. Open the
+        # connection explicitly and always close it in a finally block.
+        tn = telnetlib.Telnet(host, port, timeout=TELNET_CONNECTION_TIMEOUT)
+        try:
             if password:
                 tn.read_until(b"ENTER PASSWORD:", timeout=TELNET_CONNECTION_TIMEOUT)
                 tn.write(password.encode("ascii") + b"\n")
@@ -36,6 +41,8 @@ class BaseConvertCalledStationIdCommand(BaseCommand):
             raw_management_info = tn.read_until(
                 b"END", timeout=TELNET_CONNECTION_TIMEOUT
             )
+        finally:
+            tn.close()
         return raw_management_info
 
     def _get_openvpn_routing_info(self, host, port=7505, password=None):

--- a/openwisp_radius/tests/test_commands.py
+++ b/openwisp_radius/tests/test_commands.py
@@ -492,6 +492,66 @@ class TestCommands(FileMixin, CallCommandMixin, BaseTestCase):
     )
     @patch.object(app_settings, "OPENVPN_DATETIME_FORMAT", "%Y-%m-%d %H:%M:%S")
     @patch("openwisp_radius.tasks.convert_called_station_id")
+    def test_convert_called_station_id_closes_telnet(self, *args):
+        # regression for #727: Exscript's telnetlib.Telnet has no context
+        # manager protocol, so `with Telnet(...)` raised a TypeError that was
+        # swallowed upstream and the id was never converted. The command must
+        # open the connection and close it explicitly (not via `with`).
+        org = self._create_org(
+            id="1e4a8240-cfc8-4af0-88dd-7d487e3f7aa1",
+            name="telnet close test",
+            slug="telnet-close-test",
+        )
+        options = _RADACCT.copy()
+        options["calling_station_id"] = str(EUI("bb:bb:bb:bb:bb:0b", dialect=mac_unix))
+        options["called_station_id"] = "AA-AA-AA-AA-AA-0A"
+        options["unique_id"] = "727"
+        options["organization"] = org
+        radius_acc = self._create_radius_accounting(**options)
+
+        status = self._get_openvpn_status().encode()
+        closed = []
+
+        class FakeTelnet:
+            # mimics Exscript's Telnet: no __enter__/__exit__
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def read_until(self, *args, **kwargs):
+                return status
+
+            def write(self, *args, **kwargs):
+                pass
+
+            def close(self):
+                closed.append(True)
+
+        with patch(
+            "openwisp_radius.management.commands.base."
+            "convert_called_station_id.telnetlib.Telnet",
+            FakeTelnet,
+        ):
+            call_command("convert_called_station_id")
+
+        radius_acc.refresh_from_db()
+        self.assertEqual(radius_acc.called_station_id, "CC-CC-CC-CC-CC-0C")
+        self.assertTrue(closed, "the telnet connection should be closed")
+
+    @capture_any_output()
+    @patch.object(
+        app_settings,
+        "CALLED_STATION_IDS",
+        {
+            "1e4a8240-cfc8-4af0-88dd-7d487e3f7aa1": {
+                "openvpn_config": [
+                    {"host": "127.0.0.1", "port": 7505, "password": "somepassword"}
+                ],
+                "unconverted_ids": ["AA-AA-AA-AA-AA-0A"],
+            }
+        },
+    )
+    @patch.object(app_settings, "OPENVPN_DATETIME_FORMAT", "%Y-%m-%d %H:%M:%S")
+    @patch("openwisp_radius.tasks.convert_called_station_id")
     def test_convert_called_station_id_command_with_org_id(self, *args):
         org = self._create_org(
             id="1e4a8240-cfc8-4af0-88dd-7d487e3f7aa1",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Explanation

`Exscript.protocols.telnetlib.Telnet` is a re-implementation of the standard library's `telnetlib` and does not implement the context manager protocol (no `__enter__`/`__exit__`). As a result, the `with telnetlib.Telnet(...) as tn` in `_get_raw_management_info` raised a `TypeError`, which was silently swallowed by the broad `except Exception` in `_get_openvpn_routing_info`. The `convert_called_station_id` command therefore exited without converting any `called_station_id`, and no error was surfaced.

This opens the connection explicitly and closes it in a `finally` block instead of using a context manager.

A regression test drives the real telnet path (patching `telnetlib.Telnet` with a fake that lacks the context manager protocol, mirroring Exscript) and asserts that the `called_station_id` is converted and the connection is closed. Without the fix, the conversion silently does not happen.

Fixes #727