### PR TITLE
[fix] Validate JSON password reset confirmation organization

### DIFF
--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -598,9 +598,9 @@ class PasswordResetConfirmView(
         return super().post(request, *args, **kwargs)
 
     def validate_user(self, *args, **kwargs):
-        if self.request.POST.get("uid", None):
+        if self.request.data.get("uid", None):
             try:
-                uid = url_str_to_user_pk(self.request.POST["uid"])
+                uid = url_str_to_user_pk(self.request.data["uid"])
                 user = User.objects.get(pk=uid)
             except (User.DoesNotExist, ValidationError):
                 raise Http404()

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -1057,6 +1057,8 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn("non_field_errors", response.data)
+        self.assertIn("is not member", str(response.data["non_field_errors"]))
         user.refresh_from_db()
         self.assertTrue(user.check_password("test_password"))
 

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -1034,6 +1034,32 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         response = self.client.get(password_reset_url)
         self.assertEqual(response.status_code, 405)
 
+    def test_api_password_reset_confirm_json_enforces_membership(self):
+        other_org = self._create_org(name="other-org")
+        user = User.objects.create_user(
+            username="other-org-user",
+            password="test_password",
+            email="other-org-user@email.com",
+        )
+        self._create_org_user(organization=other_org, user=user)
+        data = {
+            "new_password1": "test_new_password",
+            "new_password2": "test_new_password",
+            "uid": user_pk_to_url_str(user),
+            "token": default_token_generator.make_token(user),
+        }
+        password_confirm_url = reverse(
+            "radius:rest_password_reset_confirm", args=[self.default_org.slug]
+        )
+        response = self.client.post(
+            password_confirm_url,
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        user.refresh_from_db()
+        self.assertTrue(user.check_password("test_password"))
+
     def test_user_accounting_list_200(self):
         auth_url = reverse("radius:user_auth_token", args=[self.default_org.slug])
         self._get_org_user()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #753.

## Description of Changes

Use `request.data` for reset confirmation membership validation so JSON requests receive the same organization check as form-encoded requests.

## Screenshot

Not applicable.
