### PR TITLE
[tests] Fixed flaky registration metrics test

### DIFF
--- a/openwisp_radius/integrations/monitoring/tests/test_metrics.py
+++ b/openwisp_radius/integrations/monitoring/tests/test_metrics.py
@@ -791,17 +791,15 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
             )
             self.assertEqual(all_points["traces"][0][0], "mobile_phone")
             self.assertEqual(all_points["traces"][0][1][-1], 1)
-            self.assertEqual(
-                all_points["summary"], {"mobile_phone": 1, "unspecified": 0}
-            )
+            self.assertEqual(all_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(all_points["summary"].get("unspecified", 0), 0)
             org_points = self._read_chart(
                 user_signup_chart, organization_id=[str(org.id)]
             )
             self.assertEqual(all_points["traces"][0][0], "mobile_phone")
             self.assertEqual(all_points["traces"][0][1][-1], 1)
-            self.assertEqual(
-                all_points["summary"], {"mobile_phone": 1, "unspecified": 0}
-            )
+            self.assertEqual(all_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(all_points["summary"].get("unspecified", 0), 0)
 
             total_user_signup_chart = total_user_signup_metric.chart_set.first()
             org_points = self._read_chart(
@@ -809,17 +807,15 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
             )
             self.assertEqual(org_points["traces"][0][0], "mobile_phone")
             self.assertEqual(org_points["traces"][0][1][-1], 1)
-            self.assertEqual(
-                org_points["summary"], {"mobile_phone": 1, "unspecified": 0}
-            )
+            self.assertEqual(org_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(org_points["summary"].get("unspecified", 0), 0)
             org_points = self._read_chart(
                 total_user_signup_chart, organization_id=[str(org.id)]
             )
             self.assertEqual(all_points["traces"][0][0], "mobile_phone")
             self.assertEqual(all_points["traces"][0][1][-1], 1)
-            self.assertEqual(
-                all_points["summary"], {"mobile_phone": 1, "unspecified": 0}
-            )
+            self.assertEqual(all_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(all_points["summary"].get("unspecified", 0), 0)
 
     def test_pending_verification_excluded_from_metrics(self):
         from ..tasks import write_user_registration_metrics

--- a/openwisp_radius/integrations/monitoring/tests/test_metrics.py
+++ b/openwisp_radius/integrations/monitoring/tests/test_metrics.py
@@ -796,10 +796,10 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
             org_points = self._read_chart(
                 user_signup_chart, organization_id=[str(org.id)]
             )
-            self.assertEqual(all_points["traces"][0][0], "mobile_phone")
-            self.assertEqual(all_points["traces"][0][1][-1], 1)
-            self.assertEqual(all_points["summary"]["mobile_phone"], 1)
-            self.assertEqual(all_points["summary"].get("unspecified", 0), 0)
+            self.assertEqual(org_points["traces"][0][0], "mobile_phone")
+            self.assertEqual(org_points["traces"][0][1][-1], 1)
+            self.assertEqual(org_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(org_points["summary"].get("unspecified", 0), 0)
 
             total_user_signup_chart = total_user_signup_metric.chart_set.first()
             org_points = self._read_chart(
@@ -812,10 +812,10 @@ class TestMetrics(CreateDeviceMonitoringMixin, BaseTransactionTestCase):
             org_points = self._read_chart(
                 total_user_signup_chart, organization_id=[str(org.id)]
             )
-            self.assertEqual(all_points["traces"][0][0], "mobile_phone")
-            self.assertEqual(all_points["traces"][0][1][-1], 1)
-            self.assertEqual(all_points["summary"]["mobile_phone"], 1)
-            self.assertEqual(all_points["summary"].get("unspecified", 0), 0)
+            self.assertEqual(org_points["traces"][0][0], "mobile_phone")
+            self.assertEqual(org_points["traces"][0][1][-1], 1)
+            self.assertEqual(org_points["summary"]["mobile_phone"], 1)
+            self.assertEqual(org_points["summary"].get("unspecified", 0), 0)
 
     def test_pending_verification_excluded_from_metrics(self):
         from ..tasks import write_user_registration_metrics


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

- Stabilizes registration metric assertions when InfluxDB omits a zero-valued `unspecified` series from a chart summary.
- Continues to require the nonzero `mobile_phone` registration count.

## Screenshot

N/A