### PR TITLE
[fix] Made SAML auth email sync case insensitive

### DIFF
--- a/openwisp_radius/saml/views.py
+++ b/openwisp_radius/saml/views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model, logout
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import UpdateView
@@ -90,47 +90,51 @@ class AssertionConsumerServiceView(
                 registered_user.is_verified = app_settings.SAML_IS_VERIFIED
                 registered_user.full_clean()
                 registered_user.save()
-            if user.email:
-                email_lowercase = user.email.lower()
+        if user.email:
+            email_lowercase = user.email.lower()
+            try:
+                user_has_primary_email = EmailAddress.objects.filter(
+                    user=user, primary=True
+                )
                 try:
-                    user_has_primary_email = EmailAddress.objects.filter(
-                        user=user, primary=True
+                    email_address = EmailAddress.objects.get(
+                        user=user, email__iexact=email_lowercase
                     )
-                    try:
-                        email_address = EmailAddress.objects.get(
-                            user=user, email__iexact=email_lowercase
-                        )
-                    except EmailAddress.DoesNotExist:
-                        email_address = EmailAddress(
-                            user=user,
-                            email=email_lowercase,
-                            verified=True,
-                            primary=not user_has_primary_email.exists(),
-                        )
+                except EmailAddress.DoesNotExist:
+                    email_address = EmailAddress(
+                        user=user,
+                        email=email_lowercase,
+                        verified=True,
+                        primary=not user_has_primary_email.exists(),
+                    )
+                    email_address.full_clean()
+                    email_address.save()
+                else:
+                    changed_fields = []
+                    if email_address.email != email_lowercase:
+                        email_address.email = email_lowercase
+                        changed_fields.append("email")
+                    if not email_address.verified:
+                        email_address.verified = True
+                        changed_fields.append("verified")
+                    if (
+                        not email_address.primary
+                        and not user_has_primary_email.exists()
+                    ):
+                        email_address.primary = True
+                        changed_fields.append("primary")
+                    if changed_fields:
                         email_address.full_clean()
-                        email_address.save()
-                    else:
-                        changed_fields = []
-                        if email_address.email != email_lowercase:
-                            email_address.email = email_lowercase
-                            changed_fields.append("email")
-                        if not email_address.verified:
-                            email_address.verified = True
-                            changed_fields.append("verified")
-                        if (
-                            not email_address.primary
-                            and not user_has_primary_email.exists()
-                        ):
-                            email_address.primary = True
-                            changed_fields.append("primary")
-                        if changed_fields:
-                            email_address.full_clean()
-                            email_address.save(update_fields=changed_fields)
-                except ValidationError:
-                    logger.exception(
-                        f'Failed email validation for "{user}" during'
-                        " SAML user creation"
-                    )
+                        email_address.save(update_fields=changed_fields)
+            except (
+                ValidationError,
+                IntegrityError,
+                EmailAddress.MultipleObjectsReturned,
+            ):
+                logger.exception(
+                    f'Failed email synchronization for "{user}" during'
+                    " SAML user creation"
+                )
 
     def customize_relay_state(self, relay_state):
         """

--- a/openwisp_radius/saml/views.py
+++ b/openwisp_radius/saml/views.py
@@ -91,18 +91,19 @@ class AssertionConsumerServiceView(
                 registered_user.full_clean()
                 registered_user.save()
             if user.email:
+                email_lowercase = user.email.lower()
                 try:
                     user_has_primary_email = EmailAddress.objects.filter(
                         user=user, primary=True
                     )
                     try:
                         email_address = EmailAddress.objects.get(
-                            user=user, email=user.email
+                            user=user, email__iexact=email_lowercase
                         )
                     except EmailAddress.DoesNotExist:
                         email_address = EmailAddress(
                             user=user,
-                            email=user.email,
+                            email=email_lowercase,
                             verified=True,
                             primary=not user_has_primary_email.exists(),
                         )
@@ -110,6 +111,9 @@ class AssertionConsumerServiceView(
                         email_address.save()
                     else:
                         changed_fields = []
+                        if email_address.email != email_lowercase:
+                            email_address.email = email_lowercase
+                            changed_fields.append("email")
                         if not email_address.verified:
                             email_address.verified = True
                             changed_fields.append("verified")

--- a/openwisp_radius/tests/test_saml/test_views.py
+++ b/openwisp_radius/tests/test_saml/test_views.py
@@ -133,6 +133,48 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
         )
 
     @capture_any_output()
+    def test_saml_login_email_case_insensitive(self):
+        def login(uid):
+            relay_state = self._get_relay_state(
+                redirect_url="https://captive-portal.example.com", org_slug="default"
+            )
+            saml_response, relay_state = self._get_saml_response_for_acs_view(
+                relay_state, uid=uid
+            )
+            return self.client.post(
+                reverse("radius:saml2_acs"),
+                {
+                    "SAMLResponse": self.b64_for_post(saml_response),
+                    "RelayState": relay_state,
+                },
+            )
+
+        with self.subTest("new email address"):
+            response = login("Org_User@example.com")
+            self.assertEqual(response.status_code, 302)
+            user = User.objects.get(email="Org_User@example.com")
+            email_address = EmailAddress.objects.get(user=user)
+            self.assertEqual(email_address.email, "org_user@example.com")
+            with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
+                response = login("Org_User@example.com")
+            self.assertEqual(response.status_code, 302)
+            mocked_logger.assert_not_called()
+            self.assertEqual(EmailAddress.objects.filter(user=user).count(), 1)
+
+        with self.subTest("existing email address"):
+            user = self._create_user(
+                username="test-user", email="Existing_User@example.com"
+            )
+            user.refresh_from_db()
+            EmailAddress.objects.filter(user=user).update(email=user.email.upper())
+            with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
+                response = login(user.email)
+            self.assertEqual(response.status_code, 302)
+            mocked_logger.assert_not_called()
+            email_address = EmailAddress.objects.get(user=user)
+            self.assertEqual(email_address.email, user.email)
+
+    @capture_any_output()
     def test_relay_state_relative_path(self):
         expected_redirect_path = "/radius/saml2/additional-info/"
         org_slug = "default"

--- a/openwisp_radius/tests/test_saml/test_views.py
+++ b/openwisp_radius/tests/test_saml/test_views.py
@@ -1,12 +1,13 @@
 import os
 from unittest.mock import patch
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 
 import swapper
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
 from django.core import mail
+from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
 from djangosaml2.tests import auth_response, conf
@@ -128,15 +129,17 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
                 },
             )
         mocked_logger.assert_called_once_with(
-            'Failed email validation for "invalid_email@example" during'
+            'Failed email synchronization for "invalid_email@example" during'
             " SAML user creation"
         )
 
     @capture_any_output()
     def test_saml_login_email_case_insensitive(self):
+        redirect_url = "https://captive-portal.example.com"
+
         def login(uid):
             relay_state = self._get_relay_state(
-                redirect_url="https://captive-portal.example.com", org_slug="default"
+                redirect_url=redirect_url, org_slug="default"
             )
             saml_response, relay_state = self._get_saml_response_for_acs_view(
                 relay_state, uid=uid
@@ -149,15 +152,35 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
                 },
             )
 
-        with self.subTest("new email address"):
-            response = login("Org_User@example.com")
+        def assert_redirect(response, user):
+            user.refresh_from_db()
             self.assertEqual(response.status_code, 302)
+            self.assertEqual(
+                get_url_or_path(response.url), "/radius/saml2/additional-info/"
+            )
+            self.assertDictEqual(
+                parse_qs(urlparse(response.url).query),
+                {
+                    "next": [
+                        f"{redirect_url}"
+                        f"?username={quote(user.username)}"
+                        f"&token={Token.objects.get(user=user).key}"
+                        "&login_method=saml"
+                    ]
+                },
+            )
+
+        with self.subTest("new email address"):
+            with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
+                response = login("Org_User@example.com")
             user = User.objects.get(email="Org_User@example.com")
+            assert_redirect(response, user)
+            mocked_logger.assert_not_called()
             email_address = EmailAddress.objects.get(user=user)
             self.assertEqual(email_address.email, "org_user@example.com")
             with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
                 response = login("Org_User@example.com")
-            self.assertEqual(response.status_code, 302)
+            assert_redirect(response, user)
             mocked_logger.assert_not_called()
             self.assertEqual(EmailAddress.objects.filter(user=user).count(), 1)
 
@@ -169,10 +192,74 @@ class TestAssertionConsumerServiceView(TestSamlMixin, TestCase):
             EmailAddress.objects.filter(user=user).update(email=user.email.upper())
             with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
                 response = login(user.email)
-            self.assertEqual(response.status_code, 302)
+            assert_redirect(response, user)
             mocked_logger.assert_not_called()
             email_address = EmailAddress.objects.get(user=user)
             self.assertEqual(email_address.email, user.email)
+
+        with self.subTest("multiple email addresses with lowercase address"):
+            user = self._create_user(
+                username="multiple-emails", email="multiple@example.com"
+            )
+            user.refresh_from_db()
+            EmailAddress.objects.filter(user=user).update(email=user.email.upper())
+            EmailAddress.objects.create(user=user, email=user.email, verified=True)
+            with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
+                response = login(user.email)
+            assert_redirect(response, user)
+            mocked_logger.assert_called_once_with(
+                f'Failed email synchronization for "{user}" during'
+                " SAML user creation"
+            )
+            self.assertEqual(EmailAddress.objects.filter(user=user).count(), 2)
+
+        with self.subTest("multiple email addresses without lowercase address"):
+            user = self._create_user(
+                username="multiple-uppercase-emails", email="multiple2@example.com"
+            )
+            user.refresh_from_db()
+            EmailAddress.objects.filter(user=user).update(email=user.email.upper())
+            EmailAddress.objects.create(
+                user=user, email=user.email.title(), verified=True
+            )
+            with patch("openwisp_radius.saml.views.logger.exception") as mocked_logger:
+                response = login(user.email)
+            assert_redirect(response, user)
+            mocked_logger.assert_called_once_with(
+                f'Failed email synchronization for "{user}" during'
+                " SAML user creation"
+            )
+            self.assertSetEqual(
+                set(
+                    EmailAddress.objects.filter(user=user).values_list(
+                        "email", flat=True
+                    )
+                ),
+                {user.email.upper(), user.email.title()},
+            )
+
+        with self.subTest("concurrent email address creation"):
+            with patch.object(EmailAddress, "save", side_effect=IntegrityError):
+                with patch(
+                    "openwisp_radius.saml.views.logger.exception"
+                ) as mocked_logger:
+                    response = login("concurrent@example.com")
+            user = User.objects.get(email="concurrent@example.com")
+            assert_redirect(response, user)
+            mocked_logger.assert_called_once_with(
+                'Failed email synchronization for "concurrent@example.com" '
+                "during SAML user creation"
+            )
+            self.assertTrue(
+                OrganizationUser.objects.filter(
+                    organization__slug="default", user=user
+                ).exists()
+            )
+            self.assertTrue(
+                RegisteredUser.objects.filter(
+                    organization__slug="default", user=user, method="saml"
+                ).exists()
+            )
 
     @capture_any_output()
     def test_relay_state_relative_path(self):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Small fix found while debugging production logs.

## Description of Changes

Production logs contained stack traces like this:

```
Traceback (most recent call last):
  File "openwisp_radius/saml/views.py", line 99, in post_login_hook
    email_address = EmailAddress.objects.get(
  File "django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "django/db/models/query.py", line 635, in get
    raise self.model.DoesNotExist(
EmailAddress.DoesNotExist: EmailAddress matching query does not exist.

Traceback (most recent call last):
  File "openwisp_radius/saml/views.py", line 109, in post_login_hook
    email_address.full_clean()
  File "django/db/models/base.py", line 1679, in full_clean
    raise ValidationError(errors)
ValidationError: {'__all__': ['Indirizzo email con questa Utente e Indirizzo email esiste già.', 'Il vincolo “unique_verified_email” è stato violato.']}
```

The logic was trying to create the same email address with different case for an existing user.

This patches fixes it by using case insensitive matching and ensuring emails are stored in lowercase form.

The email sync logic now doesn't invalidate the whole transaction if something goes wrong, because it's not a blocking issue.