### PR TITLE
[chores] Resolved non-standard DRF serialization in AccountingView

### DIFF
--- a/openwisp_radius/api/freeradius_views.py
+++ b/openwisp_radius/api/freeradius_views.py
@@ -522,6 +522,7 @@ class AccountingView(ListCreateAPIView):
                 self._handle_accounting_on(data)
             return Response(status=status.HTTP_200_OK)
         # Create or Update
+        organization = Organization.objects.get(pk=request.auth)
         try:
             instance = self.get_queryset().get(unique_id=data.get("unique_id"))
         except RadiusAccounting.DoesNotExist:
@@ -532,21 +533,18 @@ class AccountingView(ListCreateAPIView):
                 if self._is_interim_update_corner_case(error, data):
                     return Response(status=status.HTTP_200_OK)
                 raise error
-            acct_data = self._data_to_acct_model(serializer.validated_data.copy())
             try:
-                serializer.create(acct_data)
+                serializer.save(organization=organization)
             # on large systems using mac auth roaming this could happen
             except IntegrityError:
-                logger.info(f"Ignoring duplicate session {acct_data}")
+                logger.info(f"Ignoring duplicate session {serializer.validated_data}")
                 return Response(status=status.HTTP_200_OK)
-            headers = self.get_success_headers(serializer.data)
             self.send_radius_accounting_signal(serializer.validated_data)
-            return Response(status=status.HTTP_201_CREATED, headers=headers)
+            return Response(status=status.HTTP_201_CREATED)
         else:
             serializer = self.get_serializer(instance, data=data, partial=False)
             serializer.is_valid(raise_exception=True)
-            acct_data = self._data_to_acct_model(serializer.validated_data.copy())
-            serializer.update(instance, acct_data)
+            serializer.save(organization=organization)
             self.send_radius_accounting_signal(serializer.validated_data)
             return Response(status=status.HTTP_200_OK)
 
@@ -590,12 +588,6 @@ class AccountingView(ListCreateAPIView):
                 if rad.organization_id != self.request.auth:
                     return True
         return False
-
-    def _data_to_acct_model(self, valid_data):
-        acct_org = Organization.objects.get(pk=self.request.auth)
-        valid_data.pop("status_type", None)
-        valid_data["organization"] = acct_org
-        return valid_data
 
     def send_radius_accounting_signal(self, accounting_data):
         radius_accounting_success.send(

--- a/openwisp_radius/tests/test_api/test_freeradius_api.py
+++ b/openwisp_radius/tests/test_api/test_freeradius_api.py
@@ -619,10 +619,10 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
     @capture_any_output()
     @mock.patch("openwisp_radius.receivers.send_login_email.delay")
     @mock.patch(
-        "openwisp_radius.api.serializers.RadiusAccountingSerializer.create",
+        "openwisp_radius.api.serializers.RadiusAccountingSerializer.save",
         side_effect=IntegrityError,
     )
-    def test_accounting_start_integrity_error(self, create, send_login_email):
+    def test_accounting_start_integrity_error(self, save, send_login_email):
         data = self.acct_post_data
         data["status_type"] = "Start"
         data = self._get_accounting_params(**data)
@@ -630,7 +630,7 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.data)
         self.assertEqual(RadiusAccounting.objects.count(), 0)
-        create.assert_called_once()
+        save.assert_called_once()
         send_login_email.assert_not_called()
 
     @mock.patch(
@@ -758,7 +758,12 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
 
     @freeze_time(START_DATE)
     @capture_any_output()
-    def test_accounting_start_201(self):
+    @mock.patch(
+        "openwisp_radius.api.serializers.RadiusAccountingSerializer.to_representation",
+        side_effect=AssertionError,
+    )
+    @mock.patch("openwisp_radius.api.freeradius_views.radius_accounting_success.send")
+    def test_accounting_start_201(self, send, to_representation):
         self.assertEqual(RadiusAccounting.objects.count(), 0)
         data = self.acct_post_data
         data["status_type"] = "Start"
@@ -766,11 +771,18 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         response = self.post_json(data)
         self.assertEqual(response.status_code, 201)
         self.assertIsNone(response.data)
+        send.assert_called_once()
+        accounting_data = send.call_args.kwargs["accounting_data"]
+        self.assertNotIn("organization", accounting_data)
+        self.assertNotIn("status_type", accounting_data)
+        # Avoid serializing accounting data for an intentionally empty response.
+        to_representation.assert_not_called()
         self.assertEqual(RadiusAccounting.objects.count(), 1)
         self.assertAcctData(RadiusAccounting.objects.first(), data)
 
     @freeze_time(START_DATE)
-    def test_accounting_update_200(self):
+    @mock.patch("openwisp_radius.api.freeradius_views.radius_accounting_success.send")
+    def test_accounting_update_200(self, send):
         self.assertEqual(RadiusAccounting.objects.count(), 0)
         ra = self._create_radius_accounting(**self._acct_initial_data)
         data = self.acct_post_data
@@ -779,6 +791,10 @@ class TestFreeradiusApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         response = self.post_json(data)
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.data)
+        send.assert_called_once()
+        accounting_data = send.call_args.kwargs["accounting_data"]
+        self.assertNotIn("organization", accounting_data)
+        self.assertNotIn("status_type", accounting_data)
         self.assertEqual(RadiusAccounting.objects.count(), 1)
         ra.refresh_from_db()
         self.assertEqual(ra.update_time.timetuple(), now().timetuple())


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Minor clean-up, does not require an issue.

## Description of Changes

The DRF AccountingView used serializers in a non-standard way that forced us to pile gargbage on top of garbage.
This patch fixes it and makes the view use more standard DRF constructs.
