### PR TITLE
[fix] Made email lookups case insensitive

### DIFF
--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -640,7 +640,7 @@ class RegisterSerializer(
         if has_key("username"):
             user_lookup |= Q(username=data["username"])
         if has_key("email"):
-            user_lookup |= Q(email=data["email"])
+            user_lookup |= Q(email__iexact=data["email"])
         users = User.objects.filter(user_lookup).values_list("id", flat=True)
         if not users:
             # Error is not related to cross organization registration

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -1130,8 +1130,8 @@ class AbstractRadiusBatch(OrgMixin, TimeStampedEditableModel):
     def get_or_create_user(self, row, users_list, password_length):
         User = get_user_model()
         username, password, email, first_name, last_name = row
-        if email and User.objects.filter(email=email).exists():
-            user = User.objects.get(email=email)
+        if email and User.objects.filter(email__iexact=email).exists():
+            user = User.objects.get(email__iexact=email)
             return user, None
         generated_password = None
         username, password, email, first_name, last_name = row

--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -260,14 +260,17 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
         radius_settings = org2.radius_settings
         radius_settings.sms_verification = True
         radius_settings.save()
+        existing_user = User.objects.get(email=self._test_email)
+        EmailAddress.objects.filter(user=existing_user).update(verified=True)
 
         with self.subTest("Test existing email"):
             options = params.copy()
-            options["phone_number"] = "+393664255803"
+            options["email"] = self._test_email.upper()
+            options["phone_number"] = "+393664255804"
             options["username"] = "test2"
 
             response = self.client.post(url, data=options)
-            self.assertEqual(response.status_code, 409)
+            self.assertEqual(response.status_code, 409, response.data)
             expected_response_data = {
                 "details": "A user like the one being registered already exists.",
                 "organizations": [

--- a/openwisp_radius/tests/test_batch_add_users.py
+++ b/openwisp_radius/tests/test_batch_add_users.py
@@ -36,7 +36,7 @@ class TestCSVUpload(FileMixin, BaseTestCase):
             email="rohith@openwisp.com",
             expiration_date=original_expiration_date,
         )
-        reader = [["rohith", "cleartext$password", "rohith@openwisp.com", "", ""]]
+        reader = [["rohith", "cleartext$password", "ROHITH@OPENWISP.COM", "", ""]]
         batch = self._create_radius_batch(
             name="test-existing-user",
             strategy="csv",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Makes CSV user imports reuse accounts by email regardless of casing and makes cross-organization registration identify verified email duplicates regardless of casing.

## Screenshot

N/A