### PR TITLE
[tests] Refactored Selenium test logic to use new helpers

### DIFF
--- a/openwisp_radius/tests/test_selenium.py
+++ b/openwisp_radius/tests/test_selenium.py
@@ -8,7 +8,7 @@ from django.test import tag
 from django.urls import reverse
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.ui import Select, WebDriverWait
+from selenium.webdriver.support.ui import Select
 
 from openwisp_radius import tasks
 from openwisp_radius.migrations import assign_permissions_to_groups
@@ -47,22 +47,21 @@ class BasicTest(
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
 
         # Set user strategy for batch creation to 'prefix'
-        dropdown = self.wait_for_visibility(By.ID, "id_strategy", 10)
+        dropdown = self.wait_for_visibility(By.ID, "id_strategy")
         select = Select(dropdown)
         select.select_by_value("prefix")
 
         # Fill in the batch details
-        self.find_element(By.ID, "id_name", 10).send_keys("Test Batch")
+        self.find_element(By.ID, "id_name").send_keys("Test Batch")
         prefix_field = self.find_element(By.ID, "id_prefix")
         prefix_field.send_keys("test-user-")  # Set a prefix for users to be generated
-        organization = self.find_element(By.ID, "select2-id_organization-container", 10)
+        organization = self.find_element(By.ID, "select2-id_organization-container")
         organization.click()
 
         # Select the previously created organization
         option = self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         )
         option.click()
 
@@ -70,10 +69,10 @@ class BasicTest(
         self.find_element(By.ID, "id_number_of_users").send_keys("5")
 
         # Submit the form to create the users
-        self.find_element(By.CSS_SELECTOR, "input[type=submit]", 10).click()
+        self.find_element(By.CSS_SELECTOR, "input[type=submit]").click()
 
         # Verify success message
-        success_message = self.wait_for_visibility(By.CLASS_NAME, "success", 10)
+        success_message = self.wait_for_visibility(By.CLASS_NAME, "success")
         self.assertIn("was added successfully", success_message.text)
 
         # Check if the generated users are listed
@@ -94,30 +93,29 @@ class BasicTest(
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
 
         # Set strategy to CSV for importing users
-        dropdown = self.find_element(By.ID, "id_strategy", 10)
+        dropdown = self.find_element(By.ID, "id_strategy")
         select = Select(dropdown)
         select.select_by_value("csv")
 
         # Select the organization to associate with the users
-        organization = self.find_element(By.ID, "select2-id_organization-container", 10)
+        organization = self.find_element(By.ID, "select2-id_organization-container")
         organization.click()
         option = self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         )
         option.click()
 
         # Set batch name and upload CSV file for user import
-        self.find_element(By.ID, "id_name", 10).send_keys("Test Batch")
-        csv_file_input = self.find_element(By.ID, "id_csvfile", 10)
+        self.find_element(By.ID, "id_name").send_keys("Test Batch")
+        csv_file_input = self.find_element(By.ID, "id_csvfile")
         csv_file_input.send_keys(csv_file)
 
         # Submit the form to start the import
-        self.find_element(By.CSS_SELECTOR, "input[type=submit]", 10).click()
+        self.find_element(By.CSS_SELECTOR, "input[type=submit]").click()
 
         # Verify success message
-        success_message = self.wait_for_visibility(By.CLASS_NAME, "success", 10)
+        success_message = self.wait_for_visibility(By.CLASS_NAME, "success")
         self.assertIn("was added successfully", success_message.text)
 
         # Verify that users from the CSV file were created
@@ -140,30 +138,29 @@ class BasicTest(
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
 
         # Set strategy to CSV for importing users
-        dropdown = self.find_element(By.ID, "id_strategy", 10)
+        dropdown = self.find_element(By.ID, "id_strategy")
         select = Select(dropdown)
         select.select_by_value("csv")
 
         # Set batch name and select the organization
-        self.find_element(By.ID, "id_name", 10).send_keys("Hashed Password Import Test")
-        organization = self.find_element(By.ID, "select2-id_organization-container", 10)
+        self.find_element(By.ID, "id_name").send_keys("Hashed Password Import Test")
+        organization = self.find_element(By.ID, "select2-id_organization-container")
         organization.click()
         option = self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         )
         option.click()
 
         # Upload the CSV file with hashed passwords
-        csv_file_input = self.find_element(By.ID, "id_csvfile", 10)
+        csv_file_input = self.find_element(By.ID, "id_csvfile")
         csv_file_input.send_keys(csv_file)
 
         # Submit the form to import users
-        self.find_element(By.CSS_SELECTOR, "input[type=submit]", 10).click()
+        self.find_element(By.CSS_SELECTOR, "input[type=submit]").click()
 
         # Verify success message
-        success_message = self.wait_for_visibility(By.CLASS_NAME, "success", 10)
+        success_message = self.wait_for_visibility(By.CLASS_NAME, "success")
         self.assertIn("was added successfully", success_message.text)
 
         # Verify that users with hashed passwords are created
@@ -184,29 +181,28 @@ class BasicTest(
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
 
         # Set strategy to 'csv' for user generation
-        dropdown = self.find_element(By.ID, "id_strategy", 10)
+        dropdown = self.find_element(By.ID, "id_strategy")
         select = Select(dropdown)
         select.select_by_value("csv")
 
         # Select the organization and upload the CSV
-        organization = self.find_element(By.ID, "select2-id_organization-container", 10)
+        organization = self.find_element(By.ID, "select2-id_organization-container")
         organization.click()
         option = self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         )
         option.click()
 
-        self.find_element(By.ID, "id_name", 10).send_keys("CSV Test")
-        csv_file_input = self.find_element(By.ID, "id_csvfile", 10)
+        self.find_element(By.ID, "id_name").send_keys("CSV Test")
+        csv_file_input = self.find_element(By.ID, "id_csvfile")
         csv_file_input.send_keys(csv_file)
 
         # Submit the form to generate users via CSV upload
-        self.find_element(By.CSS_SELECTOR, "input[type=submit]", 10).click()
+        self.find_element(By.CSS_SELECTOR, "input[type=submit]").click()
 
         # Verify success message
-        success_message = self.wait_for_visibility(By.CLASS_NAME, "success", 10)
+        success_message = self.wait_for_visibility(By.CLASS_NAME, "success")
         self.assertIn("was added successfully", success_message.text)
 
         # Verify that the users were created
@@ -219,44 +215,39 @@ class BasicTest(
         group = RadiusGroup.objects.get(organization=organization, default=True)
         self.login()
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
-        WebDriverWait(self.web_driver, 10).until(
+        self.wait_until(
             expected_conditions.invisibility_of_element_located(
                 (By.CSS_SELECTOR, ".form-row.field-group")
-            )
+            ),
         )
         self.assertFalse(
             self.web_driver.find_element(
                 By.CSS_SELECTOR, ".form-row.field-notes"
             ).is_displayed()
         )
-        Select(self.find_element(By.ID, "id_strategy", 10)).select_by_value("prefix")
-        WebDriverWait(self.web_driver, 10).until(
+        Select(self.find_element(By.ID, "id_strategy")).select_by_value("prefix")
+        self.wait_until(
             expected_conditions.visibility_of_element_located(
                 (By.CSS_SELECTOR, ".form-row.field-group")
-            )
+            ),
         )
         self.assertTrue(
-            self.find_element(
-                By.CSS_SELECTOR, ".form-row.field-notes", 10
-            ).is_displayed()
+            self.find_element(By.CSS_SELECTOR, ".form-row.field-notes").is_displayed()
         )
         organization_field = self.find_element(
-            By.ID, "select2-id_organization-container", 10
+            By.ID, "select2-id_organization-container"
         )
         organization_field.click()
         option = self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         )
         option.click()
-        WebDriverWait(self.web_driver, 10).until(
-            lambda driver: (
-                driver.find_element(By.ID, "id_group").get_attribute("value")
-                == str(group.pk)
-            )
+        self.wait_until(
+            lambda driver: driver.find_element(By.ID, "id_group").get_attribute("value")
+            == str(group.pk),
         )
-        self.assertEqual(self.get_browser_errors(), [])
+        self.assert_no_browser_errors()
 
     def test_batch_group_preserved_after_validation_error(self):
         organization = self._create_org()
@@ -264,18 +255,19 @@ class BasicTest(
         group = RadiusGroup.objects.create(name="guests", organization=organization)
         self.login()
         self.open(reverse("admin:openwisp_radius_radiusbatch_add"))
-        Select(self.find_element(By.ID, "id_strategy", 10)).select_by_value("prefix")
+        Select(self.find_element(By.ID, "id_strategy")).select_by_value("prefix")
         organization_field = self.find_element(
-            By.ID, "select2-id_organization-container", 10
+            By.ID, "select2-id_organization-container"
         )
         organization_field.click()
         self.find_element(
             By.XPATH,
             "//li[contains(@class, 'select2-results__option') and text()='test org']",
-            10,
         ).click()
-        WebDriverWait(self.web_driver, 10).until(
-            lambda driver: driver.find_element(By.ID, "id_group").get_attribute("value")
+        self.wait_until(
+            lambda driver: driver.find_element(By.ID, "id_group").get_attribute(
+                "value"
+            ),
         )
         self.web_driver.execute_script(
             "django.jQuery('#id_group')"
@@ -284,24 +276,22 @@ class BasicTest(
             str(group.pk),
             str(group),
         )
-        self.find_element(By.ID, "id_name", 10).send_keys("Test batch")
-        self.find_element(By.ID, "id_prefix", 10).send_keys("test-prefix")
-        self.find_element(By.CSS_SELECTOR, "input[type=submit]", 10).click()
-        WebDriverWait(self.web_driver, 10).until(
+        self.find_element(By.ID, "id_name").send_keys("Test batch")
+        self.find_element(By.ID, "id_prefix").send_keys("test-prefix")
+        self.find_element(By.CSS_SELECTOR, "input[type=submit]").click()
+        self.wait_until(
             expected_conditions.presence_of_element_located(
                 (By.CSS_SELECTOR, ".errorlist")
-            )
+            ),
         )
-        WebDriverWait(self.web_driver, 10).until(
-            lambda driver: driver.execute_script("return django.jQuery.active === 0")
+        self.wait_for_script(
+            "return django.jQuery.active === 0",
         )
-        WebDriverWait(self.web_driver, 10).until(
-            lambda driver: (
-                driver.find_element(By.ID, "id_group").get_attribute("value")
-                == str(group.pk)
-            )
+        self.wait_until(
+            lambda driver: driver.find_element(By.ID, "id_group").get_attribute("value")
+            == str(group.pk),
         )
-        self.assertEqual(self.get_browser_errors(), [])
+        self.assert_no_browser_errors()
 
     def test_view_only_change_page_shows_readonly_fields(self):
         org = self._get_org()
@@ -374,15 +364,16 @@ class TestRadiusBatchWebSockets(
         )
         self.open(change_url)
         processing_message_element = self.wait_for_visibility(
-            By.CSS_SELECTOR, ".messagelist .warning", 10
+            By.CSS_SELECTOR, ".messagelist .warning"
         )
         self.assertIn("Processing:", processing_message_element.text)
         tasks.process_radius_batch(batch.pk, number_of_users=0)
-        WebDriverWait(self.web_driver, 10).until(
-            expected_conditions.staleness_of(processing_message_element)
+        self.wait_until(
+            expected_conditions.staleness_of(processing_message_element),
+            timeout=5,
         )
         status_field = (By.CSS_SELECTOR, "div.field-status .readonly")
-        WebDriverWait(self.web_driver, 10).until(
+        self.wait_until(
             expected_conditions.text_to_be_present_in_element(status_field, "Completed")
         )
-        self.assertEqual(self.get_browser_errors(), [])
+        self.assert_no_browser_errors()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A. This small test-maintenance change does not require a related issue.

## Description of Changes

Refactors Selenium tests to use `wait_until()`, `wait_for_script()`, and `assert_no_browser_errors()`. Removes redundant timeout overrides and keeps the standard two-second wait by default, with five seconds reserved for WebSocket reloads.

## Screenshot

N/A. This change affects test code only.