### PR TITLE
[fix] Prevented SMS verification bypasses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ If instructions conflict, repository config and CI workflows win first, official
 
 - Watch for cross-tenant data leaks, permission bypasses, insecure credentials, unsafe redirects, unsafe file paths, token/session issues, and secrets.
 - Preserve validation around RADIUS credentials, accounting data, CSV imports, private storage, SAML/social login payloads, notification payloads, and URLs.
+- Never use PhoneToken.objects.create() as it can bypass policy and quota validation.
 
 ## Troubleshooting
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -731,7 +731,10 @@ Create SMS token
 **Requires the user auth token (Bearer Token)**.
 
 Used for SMS verification, sends a code via SMS to the phone number of the
-user.
+user. The number must comply with
+:ref:`OPENWISP_RADIUS_ALLOWED_MOBILE_PREFIXES
+<openwisp_radius_allowed_mobile_prefixes>` and
+``OPENWISP_RADIUS_ALLOW_FIXED_LINE_OR_MOBILE``.
 
 .. code-block:: text
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -214,6 +214,11 @@ The rate descriptions used in ``DEFAULT_THROTTLE_RATES`` may include
 ``second``, ``minute``, ``hour`` or ``day`` as the throttle period,
 setting it to ``None`` will result in no throttling.
 
+SMS token requests use the connection address in ``REMOTE_ADDR`` for their
+daily IP limit. When deploying behind a reverse proxy, configure it to
+replace ``REMOTE_ADDR`` with the client address and discard
+client-supplied forwarding headers.
+
 List of Endpoints
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -498,11 +498,12 @@ Using the setting above will only allow phone numbers from the UK
 
 **Default**: ``False``
 
-OpenWISP RADIUS only allow using mobile phone numbers for user
+OpenWISP RADIUS only allows using mobile phone numbers for user
 registration and SMS verification. This can cause issues in regions where
-fixed line and mobile phone numbers uses the same pattern (e.g. USA).
-Setting the value to ``True`` would make phone number type checking less
-strict.
+fixed-line and mobile phone numbers use the same pattern (e.g. USA).
+Setting the value to ``True`` allows ``MOBILE`` and
+``FIXED_LINE_OR_MOBILE`` phone numbers for registration and SMS
+verification.
 
 .. _openwisp_radius_optional_registration_fields:
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -468,10 +468,11 @@ accounting will be saved as usual.
 
 This setting is used to specify a list of international mobile prefixes
 which should be allowed to register into the system via the :ref:`user
-registration API <radius_user_registration>`.
+registration API <radius_user_registration>` and to receive SMS
+verification tokens.
 
 That is, only users with phone numbers using the specified international
-prefixes will be allowed to register.
+prefixes will be allowed to register or receive SMS verification tokens.
 
 Leaving this unset or setting it to an empty list (``[]``) will
 effectively allow any international mobile prefix to register (which is
@@ -498,9 +499,10 @@ Using the setting above will only allow phone numbers from the UK
 **Default**: ``False``
 
 OpenWISP RADIUS only allow using mobile phone numbers for user
-registration. This can cause issues in regions where fixed line and mobile
-phone numbers uses the same pattern (e.g. USA). Setting the value to
-``True`` would make phone number type checking less strict.
+registration and SMS verification. This can cause issues in regions where
+fixed line and mobile phone numbers uses the same pattern (e.g. USA).
+Setting the value to ``True`` would make phone number type checking less
+strict.
 
 .. _openwisp_radius_optional_registration_fields:
 

--- a/openwisp_radius/api/serializers.py
+++ b/openwisp_radius/api/serializers.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 
-import phonenumbers
 import swapper
 from allauth.account.adapter import get_adapter
 from allauth.account.utils import setup_user_email
@@ -18,7 +17,6 @@ from django.utils import formats, timezone
 from django.utils.translation import gettext_lazy as _
 from drf_yasg.utils import swagger_serializer_method
 from phonenumber_field.serializerfields import PhoneNumberField
-from phonenumbers import PhoneNumberType, phonenumberutil
 from rest_framework import serializers
 from rest_framework.authtoken.serializers import (
     AuthTokenSerializer as BaseAuthTokenSerializer,
@@ -38,6 +36,7 @@ from openwisp_users.backends import UsersAuthenticationBackend
 from openwisp_utils.api.serializers import ValidatedModelSerializer
 
 from .. import settings as app_settings
+from ..base.validators import is_mobile_phone_number, is_mobile_prefix_allowed
 from ..counters.exceptions import SkipCheck
 from ..utils import (
     get_group_checks,
@@ -120,13 +119,7 @@ class AuthTokenSerializer(BaseAuthTokenSerializer):
 
 class AllowedMobilePrefixMixin(object):
     def is_prefix_allowed(self, phone_number, mobile_prefixes):
-        """
-        Verifies if a phone number's international prefix is allowed
-        """
-        country_code = phonenumbers.parse(str(phone_number)).country_code
-        if not mobile_prefixes:
-            return True
-        return "+" + str(country_code) in mobile_prefixes
+        return is_mobile_prefix_allowed(phone_number, mobile_prefixes)
 
 
 class AuthorizeSerializer(serializers.Serializer):
@@ -672,11 +665,10 @@ class RegisterSerializer(
                 raise serializers.ValidationError(
                     _("This international mobile prefix is not allowed.")
                 )
-            phone_number_type = phonenumberutil.number_type(phone_number)
-            allowed_types = [PhoneNumberType.MOBILE]
-            if app_settings.ALLOW_FIXED_LINE_OR_MOBILE:
-                allowed_types.append(PhoneNumberType.FIXED_LINE_OR_MOBILE)
-            if phone_number_type not in allowed_types:
+            if not is_mobile_phone_number(
+                phone_number,
+                allow_fixed_line_or_mobile=app_settings.ALLOW_FIXED_LINE_OR_MOBILE,
+            ):
                 raise serializers.ValidationError(
                     _("Only mobile phone numbers are allowed.")
                 )

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -793,23 +793,30 @@ class CreatePhoneTokenView(
             ip=self.get_ident(request),
             phone_number=phone_number,
         )
+        org_cooldown = self.organization.radius_settings.sms_cooldown
         try:
-            phone_token.full_clean()
-            if kwargs.get("enforce_unverified", True):
-                phone_token._validate_already_verified(organization=self.organization)
+            with transaction.atomic():
+                # acquire lock on the user to prevent bypassing
+                # cooldown period with concurrent requests
+                phone_token.user = (
+                    get_user_model().objects.select_for_update().get(pk=request.user.pk)
+                )
+                phone_token.full_clean()
+                if kwargs.get("enforce_unverified", True):
+                    phone_token._validate_already_verified(
+                        organization=self.organization
+                    )
+                self.enforce_sms_request_cooldown(org_cooldown, phone_number)
+                phone_token.save()
         except ValidationError as e:
             error_dict = self._get_error_dict(e)
             raise serializers.ValidationError(error_dict)
         except UserAlreadyVerified as e:
             raise serializers.ValidationError({"user": str(e)})
-        org_cooldown = self.organization.radius_settings.sms_cooldown
-        try:
-            self.enforce_sms_request_cooldown(org_cooldown, phone_number)
         except SmsAttemptCooldownException as e:
             return Response(
                 {"non_field_errors": [str(e)], "cooldown": e.cooldown}, status=400
             )
-        phone_token.save()
         return Response(
             {"cooldown": org_cooldown},
             status=201,

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -762,6 +762,14 @@ class CreatePhoneTokenView(
         IsAuthenticated,
     )
 
+    def get_ident(self, request):
+        """Override DRF's client-ID lookup for the SMS token IP quota.
+
+        X-Forwarded-For is caller-controlled and could bypass the quota.
+        Reverse proxies must replace REMOTE_ADDR with the client address.
+        """
+        return request.META["REMOTE_ADDR"]
+
     @swagger_auto_schema(
         operation_description=("""
             **Requires the user auth token (Bearer Token).**

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -786,7 +786,8 @@ class CreatePhoneTokenView(
     def create(self, *args, **kwargs):
         request = self.request
         self.validate_membership(request.user)
-        phone_number = request.data.get("phone_number", request.user.phone_number)
+        # only the change phone number endpoint can change the phone number
+        phone_number = kwargs.pop("phone_number", request.user.phone_number)
         phone_token = PhoneToken(
             user=request.user,
             organization=self.organization,
@@ -997,7 +998,9 @@ class ChangePhoneNumberView(ThrottledAPIMixin, CreatePhoneTokenView):
         # the user is marked unverified, so that if the
         # creation of the phone token fails, the
         # the user's is_verified state remains unchanged
-        self.create_phone_token(*args, **kwargs)
+        self.create_phone_token(
+            *args, phone_number=serializer.validated_data["phone_number"], **kwargs
+        )
         serializer.save()
         return Response(None, status=200)
 

--- a/openwisp_radius/api/views.py
+++ b/openwisp_radius/api/views.py
@@ -768,7 +768,7 @@ class CreatePhoneTokenView(
         X-Forwarded-For is caller-controlled and could bypass the quota.
         Reverse proxies must replace REMOTE_ADDR with the client address.
         """
-        return request.META["REMOTE_ADDR"]
+        return request.META.get("REMOTE_ADDR")
 
     @swagger_auto_schema(
         operation_description=("""

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -60,7 +60,12 @@ from ..utils import (
     prefix_generate_users,
     validate_csvfile,
 )
-from .validators import ipv6_network_validator, password_reset_url_validator
+from .validators import (
+    ipv6_network_validator,
+    is_mobile_phone_number,
+    is_mobile_prefix_allowed,
+    password_reset_url_validator,
+)
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -1674,8 +1679,26 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
     def clean(self):
         if not hasattr(self, "user"):
             return
+        self._validate_phone_number_prefix()
+        self._validate_phone_number_type()
         self._validate_phone_number_uniqueness()
         self._validate_max_attempts()
+
+    def _validate_phone_number_prefix(self):
+        mobile_prefixes = self.organization.radius_settings.allowed_mobile_prefixes_list
+        if not is_mobile_prefix_allowed(self.phone_number, mobile_prefixes):
+            raise ValidationError(
+                {"phone_number": _("This international mobile prefix is not allowed.")}
+            )
+
+    def _validate_phone_number_type(self):
+        if not is_mobile_phone_number(
+            self.phone_number,
+            allow_fixed_line_or_mobile=app_settings.ALLOW_FIXED_LINE_OR_MOBILE,
+        ):
+            raise ValidationError(
+                {"phone_number": _("Only mobile phone numbers are allowed.")}
+            )
 
     def _validate_phone_number_uniqueness(self):
         """
@@ -1741,6 +1764,8 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
                     user=self.user
                 )
             )
+        self._validate_phone_number_prefix()
+        self._validate_phone_number_type()
         org_radius_settings = self.organization.radius_settings
         message = _(org_radius_settings.sms_message).format(
             organization=org_radius_settings.organization.name, code=self.token
@@ -1750,7 +1775,29 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
             from_phone=str(org_radius_settings.sms_sender),
             to=[str(self.phone_number)],
         )
-        sms_message.send(meta_data=org_radius_settings.sms_meta_data)
+        try:
+            sms_message.send(meta_data=org_radius_settings.sms_meta_data)
+        except Exception:
+            logger.exception(
+                "Failed to submit SMS token %s to the SMS backend for phone number "
+                "%s, user %s, organization %s, IP address %s.",
+                self.pk,
+                str(self.phone_number),
+                self.user.pk,
+                self.organization.pk,
+                self.ip,
+            )
+            raise
+        else:
+            logger.info(
+                "SMS token %s was submitted to the SMS backend for phone number %s, "
+                "user %s, organization %s, IP address %s.",
+                self.pk,
+                str(self.phone_number),
+                self.user.pk,
+                self.organization.pk,
+                self.ip,
+            )
 
     def is_valid(self, token, organization=None):
         self.attempts += 1

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -1654,6 +1654,10 @@ class AbstractOrganizationRadiusSettings(UUIDModel):
 class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
     """
     Phone Verification Token (sent via SMS)
+
+    WARNING: Application code must not create or save phone tokens directly
+    with self.objects.create() or calling self.save() without first calling
+    self.full_clean(), as it can bypass policy and quota validation.
     """
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
@@ -1679,10 +1683,13 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
     def clean(self):
         if not hasattr(self, "user"):
             return
-        self._validate_phone_number_prefix()
-        self._validate_phone_number_type()
+        self._validate_phone_number_policy()
         self._validate_phone_number_uniqueness()
         self._validate_max_attempts()
+
+    def _validate_phone_number_policy(self):
+        self._validate_phone_number_prefix()
+        self._validate_phone_number_type()
 
     def _validate_phone_number_prefix(self):
         mobile_prefixes = self.organization.radius_settings.allowed_mobile_prefixes_list
@@ -1764,9 +1771,12 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
                     user=self.user
                 )
             )
-        self._validate_phone_number_prefix()
-        self._validate_phone_number_type()
+        try:
+            self._validate_phone_number_policy()
+        except ValidationError as error:
+            raise ValueError(error) from None
         org_radius_settings = self.organization.radius_settings
+        phone_number = f"{str(self.phone_number)[:-4]}****"
         message = _(org_radius_settings.sms_message).format(
             organization=org_radius_settings.organization.name, code=self.token
         )
@@ -1778,19 +1788,21 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
         try:
             sms_message.send(meta_data=org_radius_settings.sms_meta_data)
         except Exception:
-            logger.exception(
-                "Failed to submit SMS token %s to the SMS backend for user %s, "
-                "organization %s.",
+            logger.error(
+                "Failed to submit SMS token %s to the SMS backend for phone number %s, "
+                "user %s, organization %s.",
                 self.pk,
+                phone_number,
                 self.user.pk,
                 self.organization.pk,
             )
             raise
         else:
             logger.info(
-                "SMS token %s was submitted to the SMS backend for user %s, "
-                "organization %s.",
+                "SMS token %s was submitted to the SMS backend for phone number %s, "
+                "user %s, organization %s.",
                 self.pk,
+                phone_number,
                 self.user.pk,
                 self.organization.pk,
             )

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -1779,24 +1779,20 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
             sms_message.send(meta_data=org_radius_settings.sms_meta_data)
         except Exception:
             logger.exception(
-                "Failed to submit SMS token %s to the SMS backend for phone number "
-                "%s, user %s, organization %s, IP address %s.",
+                "Failed to submit SMS token %s to the SMS backend for user %s, "
+                "organization %s.",
                 self.pk,
-                str(self.phone_number),
                 self.user.pk,
                 self.organization.pk,
-                self.ip,
             )
             raise
         else:
             logger.info(
-                "SMS token %s was submitted to the SMS backend for phone number %s, "
-                "user %s, organization %s, IP address %s.",
+                "SMS token %s was submitted to the SMS backend for user %s, "
+                "organization %s.",
                 self.pk,
-                str(self.phone_number),
                 self.user.pk,
                 self.organization.pk,
-                self.ip,
             )
 
     def is_valid(self, token, organization=None):

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -57,6 +57,7 @@ from ..utils import (
     generate_sms_token,
     get_sms_default_valid_until,
     load_model,
+    mask_phone_number,
     prefix_generate_users,
     validate_csvfile,
 )
@@ -1739,7 +1740,13 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
         # from bypassing the daily limit checks
         locked_qs = qs.select_for_update()
         locked_qs.filter(user=self.user).first()
-        locked_qs.filter(ip=self.ip).first()
+        # if it's a new IP, acquire a generic lock
+        # to prevent concurrent requests bypassing limits
+        if not locked_qs.filter(ip=self.ip).first():
+            # This is done on purpose, slow but safe!
+            # Generating millions of SMS messages per
+            # day is out of scope!
+            PhoneToken.objects.select_for_update().first()
         # limit generation of tokens per day by user
         user_token_count = qs.filter(user=self.user).count()
         if user_token_count >= app_settings.SMS_TOKEN_MAX_USER_DAILY:
@@ -1781,7 +1788,6 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
         except ValidationError as error:
             raise ValueError(error) from None
         org_radius_settings = self.organization.radius_settings
-        phone_number = f"{str(self.phone_number)[:-4]}****"
         message = _(org_radius_settings.sms_message).format(
             organization=org_radius_settings.organization.name, code=self.token
         )
@@ -1790,6 +1796,11 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
             from_phone=str(org_radius_settings.sms_sender),
             to=[str(self.phone_number)],
         )
+        # Masking the full phone number allows to keep a fragment for debugging.
+        # This aligns with SMS provider logs, which usually only track the
+        # recipient's phone number and the sender's IP and are not aware
+        # of our internal UUIDs.
+        masked_phone_number = mask_phone_number(self.phone_number)
         try:
             sms_message.send(meta_data=org_radius_settings.sms_meta_data)
         except Exception:
@@ -1797,7 +1808,7 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
                 "Failed to submit SMS token %s to the SMS backend for phone number %s, "
                 "user %s, organization %s.",
                 self.pk,
-                phone_number,
+                masked_phone_number,
                 self.user.pk,
                 self.organization.pk,
             )
@@ -1807,7 +1818,7 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
                 "SMS token %s was submitted to the SMS backend for phone number %s, "
                 "user %s, organization %s.",
                 self.pk,
-                phone_number,
+                masked_phone_number,
                 self.user.pk,
                 self.organization.pk,
             )

--- a/openwisp_radius/base/models.py
+++ b/openwisp_radius/base/models.py
@@ -1735,6 +1735,11 @@ class AbstractPhoneToken(OrgMixin, TimeStampedEditableModel):
         date_end = date_start + timedelta(days=1)
         PhoneToken = load_model("PhoneToken")
         qs = PhoneToken.objects.filter(created__range=[date_start, date_end])
+        # acquire locks to prevent concurrent requests
+        # from bypassing the daily limit checks
+        locked_qs = qs.select_for_update()
+        locked_qs.filter(user=self.user).first()
+        locked_qs.filter(ip=self.ip).first()
         # limit generation of tokens per day by user
         user_token_count = qs.filter(user=self.user).count()
         if user_token_count >= app_settings.SMS_TOKEN_MAX_USER_DAILY:

--- a/openwisp_radius/base/validators.py
+++ b/openwisp_radius/base/validators.py
@@ -13,7 +13,10 @@ def is_mobile_prefix_allowed(phone_number, mobile_prefixes):
     # Let other field validators raise for missing values.
     if not phone_number:
         return True
-    country_code = phonenumbers.parse(str(phone_number)).country_code
+    try:
+        country_code = phonenumbers.parse(str(phone_number)).country_code
+    except phonenumbers.NumberParseException:
+        return False
     return not mobile_prefixes or f"+{country_code}" in mobile_prefixes
 
 

--- a/openwisp_radius/base/validators.py
+++ b/openwisp_radius/base/validators.py
@@ -1,10 +1,30 @@
 from ipaddress import IPv6Network, ip_network
 
+import phonenumbers
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.utils.translation import gettext_lazy as _
+from phonenumbers import PhoneNumberType, phonenumberutil
 
 URL_VALIDATOR = URLValidator()
+
+
+def is_mobile_prefix_allowed(phone_number, mobile_prefixes):
+    # Let other field validators raise for missing values.
+    if not phone_number:
+        return True
+    country_code = phonenumbers.parse(str(phone_number)).country_code
+    return not mobile_prefixes or f"+{country_code}" in mobile_prefixes
+
+
+def is_mobile_phone_number(phone_number, allow_fixed_line_or_mobile=False):
+    # Let other field validators raise for missing values.
+    if not phone_number:
+        return True
+    allowed_types = [PhoneNumberType.MOBILE]
+    if allow_fixed_line_or_mobile:
+        allowed_types.append(PhoneNumberType.FIXED_LINE_OR_MOBILE)
+    return phonenumberutil.number_type(phone_number) in allowed_types
 
 
 def ipv6_network_validator(value):

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -263,6 +263,7 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
 
     @capture_any_output()
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    @freeze_time(_TEST_DATE)
     def test_create_phone_token_uses_client_ip_for_daily_limit(
         self, send_messages_mock
     ):

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -7,6 +7,8 @@ from allauth.account.models import EmailAddress
 from dateutil import parser
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from django.db import transaction
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -321,6 +323,50 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
             "Changing X-Forwarded-For must not bypass the daily SMS limit.",
         )
         self.assertEqual(PhoneToken.objects.filter(ip="192.0.2.1").count(), 1)
+        send_messages_mock.assert_called_once()
+
+    @freeze_time(_TEST_DATE)
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_locks_daily_quota(self, send_messages_mock):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        with mock.patch(
+            "openwisp_radius.api.views.transaction.atomic",
+            wraps=transaction.atomic,
+        ) as atomic_mock:
+            with mock.patch.object(
+                QuerySet,
+                "select_for_update",
+                autospec=True,
+                side_effect=QuerySet.select_for_update,
+            ) as select_for_update_mock:
+                response = self.client.post(
+                    url, HTTP_AUTHORIZATION=f"Bearer {token.key}"
+                )
+        self.assertEqual(response.status_code, 201)
+        atomic_mock.assert_called_once_with()
+        self.assertIn(
+            PhoneToken,
+            [call.args[0].model for call in select_for_update_mock.call_args_list],
+            "Daily quota checks must lock a PhoneToken row.",
+        )
+        send_messages_mock.assert_called_once()
+
+    @freeze_time(_TEST_DATE)
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_locks_user_for_cooldown(self, send_messages_mock):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        with mock.patch.object(
+            get_user_model().objects,
+            "select_for_update",
+            wraps=get_user_model().objects.select_for_update,
+        ) as select_for_update_mock:
+            response = self.client.post(url, HTTP_AUTHORIZATION=f"Bearer {token.key}")
+        self.assertEqual(response.status_code, 201)
+        select_for_update_mock.assert_called_once_with()
         send_messages_mock.assert_called_once()
 
     @capture_any_output()

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -194,6 +194,113 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         self.assertIsNotNone(phonetoken)
         send_messages_mock.assert_called_once()
 
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_rejects_disallowed_prefix(self, send_messages_mock):
+        self._register_user()
+        self.default_org.radius_settings.allowed_mobile_prefixes = "+39"
+        self.default_org.radius_settings.save()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        response = self.client.post(
+            url,
+            json.dumps({"phone_number": "+44 7795 106991"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.key}",
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            "SMS token requests must reject destinations with disallowed prefixes.",
+        )
+        self.assertEqual(PhoneToken.objects.count(), 0)
+        send_messages_mock.assert_not_called()
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_rejects_fixed_line_number(self, send_messages_mock):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        response = self.client.post(
+            url,
+            json.dumps({"phone_number": "+3903031234"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.key}",
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            "SMS token requests must reject fixed-line destinations.",
+        )
+        self.assertEqual(
+            str(response.data["phone_number"][0]),
+            "Only mobile phone numbers are allowed.",
+        )
+        self.assertEqual(PhoneToken.objects.count(), 0)
+        send_messages_mock.assert_not_called()
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_change_phone_number_rejects_fixed_line_number(self, send_messages_mock):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_number_change", args=[self.default_org.slug])
+        response = self.client.post(
+            url,
+            json.dumps({"phone_number": "+3903031234"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.key}",
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            "Phone changes must reject fixed-line destinations.",
+        )
+        self.assertEqual(
+            str(response.data["phone_number"][0]),
+            "Only mobile phone numbers are allowed.",
+        )
+        self.assertEqual(PhoneToken.objects.count(), 0)
+        send_messages_mock.assert_not_called()
+
+    @capture_any_output()
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_uses_client_ip_for_daily_limit(
+        self, send_messages_mock
+    ):
+        self._register_user()
+        user1 = User.objects.get(email=self._test_email)
+        user2 = self._create_user(
+            username="test2",
+            email="test2@example.com",
+            password="test",
+            phone_number="+393664255802",
+            is_active=True,
+        )
+        self._create_org_user(user=user2)
+        token1 = Token.objects.get(user=user1)
+        token2 = Token.objects.create(user=user2)
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        with mock.patch.object(app_settings, "SMS_TOKEN_MAX_IP_DAILY", 1):
+            first_response = self.client.post(
+                url,
+                HTTP_AUTHORIZATION=f"Bearer {token1.key}",
+                REMOTE_ADDR="192.0.2.1",
+                HTTP_X_FORWARDED_FOR="203.0.113.1",
+            )
+            second_response = self.client.post(
+                url,
+                HTTP_AUTHORIZATION=f"Bearer {token2.key}",
+                REMOTE_ADDR="192.0.2.1",
+                HTTP_X_FORWARDED_FOR="203.0.113.2",
+            )
+        self.assertEqual(first_response.status_code, 201)
+        self.assertEqual(
+            second_response.status_code,
+            400,
+            "Changing X-Forwarded-For must not bypass the daily SMS limit.",
+        )
+        self.assertEqual(PhoneToken.objects.filter(ip="192.0.2.1").count(), 1)
+        send_messages_mock.assert_called_once()
+
     @capture_any_output()
     def test_create_phone_token_400_not_member(self):
         self._register_user()
@@ -849,12 +956,13 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
             radius_settings.full_clean()
             radius_settings.save()
             phone_number = "+1 7795 106991"
-            r = self.client.post(
-                url,
-                json.dumps({"phone_number": phone_number}),
-                content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {user_token.key}",
-            )
+            with mock.patch.object(app_settings, "ALLOW_FIXED_LINE_OR_MOBILE", True):
+                r = self.client.post(
+                    url,
+                    json.dumps({"phone_number": phone_number}),
+                    content_type="application/json",
+                    HTTP_AUTHORIZATION=f"Bearer {user_token.key}",
+                )
             self.assertEqual(r.status_code, 200)
             self.assertEqual(phone_token_qs.count(), 2)
             code = phone_token_qs.get(user=user, phone_number=phone_number).token

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -239,6 +239,27 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         send_messages_mock.assert_not_called()
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_create_phone_token_rejects_malformed_phone_number(
+        self, send_messages_mock
+    ):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        response = self.client.post(
+            url,
+            json.dumps({"phone_number": "garbage"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.key}",
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            "SMS token requests must reject malformed phone numbers.",
+        )
+        self.assertEqual(PhoneToken.objects.count(), 0)
+        send_messages_mock.assert_not_called()
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
     def test_change_phone_number_rejects_fixed_line_number(self, send_messages_mock):
         self._register_user()
         token = Token.objects.last()

--- a/openwisp_radius/tests/test_api/test_phone_verification.py
+++ b/openwisp_radius/tests/test_api/test_phone_verification.py
@@ -197,12 +197,31 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         send_messages_mock.assert_called_once()
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
-    def test_create_phone_token_rejects_disallowed_prefix(self, send_messages_mock):
+    def test_create_phone_token_uses_stored_phone_number(self, send_messages_mock):
+        self._register_user()
+        token = Token.objects.last()
+        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        response = self.client.post(
+            url,
+            json.dumps({"phone_number": "+44 7795 106991"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token.key}",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            str(PhoneToken.objects.get().phone_number),
+            self._extra_registration_params["phone_number"],
+            "The generic SMS-token endpoint must use the stored phone number.",
+        )
+        send_messages_mock.assert_called_once()
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_change_phone_number_rejects_disallowed_prefix(self, send_messages_mock):
         self._register_user()
         self.default_org.radius_settings.allowed_mobile_prefixes = "+39"
         self.default_org.radius_settings.save()
         token = Token.objects.last()
-        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        url = reverse("radius:phone_number_change", args=[self.default_org.slug])
         response = self.client.post(
             url,
             json.dumps({"phone_number": "+44 7795 106991"}),
@@ -212,41 +231,18 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         self.assertEqual(
             response.status_code,
             400,
-            "SMS token requests must reject destinations with disallowed prefixes.",
+            "Phone changes must reject destinations with disallowed prefixes.",
         )
         self.assertEqual(PhoneToken.objects.count(), 0)
         send_messages_mock.assert_not_called()
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
-    def test_create_phone_token_rejects_fixed_line_number(self, send_messages_mock):
-        self._register_user()
-        token = Token.objects.last()
-        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
-        response = self.client.post(
-            url,
-            json.dumps({"phone_number": "+3903031234"}),
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {token.key}",
-        )
-        self.assertEqual(
-            response.status_code,
-            400,
-            "SMS token requests must reject fixed-line destinations.",
-        )
-        self.assertEqual(
-            str(response.data["phone_number"][0]),
-            "Only mobile phone numbers are allowed.",
-        )
-        self.assertEqual(PhoneToken.objects.count(), 0)
-        send_messages_mock.assert_not_called()
-
-    @mock.patch("openwisp_radius.utils.SmsMessage.send")
-    def test_create_phone_token_rejects_malformed_phone_number(
+    def test_change_phone_number_rejects_malformed_phone_number(
         self, send_messages_mock
     ):
         self._register_user()
         token = Token.objects.last()
-        url = reverse("radius:phone_token_create", args=[self.default_org.slug])
+        url = reverse("radius:phone_number_change", args=[self.default_org.slug])
         response = self.client.post(
             url,
             json.dumps({"phone_number": "garbage"}),
@@ -256,7 +252,7 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
         self.assertEqual(
             response.status_code,
             400,
-            "SMS token requests must reject malformed phone numbers.",
+            "Phone changes must reject malformed phone numbers.",
         )
         self.assertEqual(PhoneToken.objects.count(), 0)
         send_messages_mock.assert_not_called()
@@ -330,6 +326,16 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
     def test_create_phone_token_locks_daily_quota(self, send_messages_mock):
         self._register_user()
         token = Token.objects.last()
+        phone_token = PhoneToken.objects.create(
+            user=token.user,
+            organization=self.default_org,
+            ip="192.0.2.1",
+            phone_number=token.user.phone_number,
+        )
+        PhoneToken.objects.filter(pk=phone_token.pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        send_messages_mock.reset_mock()
         url = reverse("radius:phone_token_create", args=[self.default_org.slug])
         with mock.patch(
             "openwisp_radius.api.views.transaction.atomic",
@@ -341,9 +347,14 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
                 autospec=True,
                 side_effect=QuerySet.select_for_update,
             ) as select_for_update_mock:
-                response = self.client.post(
-                    url, HTTP_AUTHORIZATION=f"Bearer {token.key}"
-                )
+                with mock.patch.object(
+                    PhoneToken.objects,
+                    "select_for_update",
+                    wraps=PhoneToken.objects.select_for_update,
+                ) as generic_lock_mock:
+                    response = self.client.post(
+                        url, HTTP_AUTHORIZATION=f"Bearer {token.key}"
+                    )
         self.assertEqual(response.status_code, 201)
         atomic_mock.assert_called_once_with()
         self.assertIn(
@@ -351,6 +362,7 @@ class TestPhoneVerification(ApiTokenMixin, BaseTestCase):
             [call.args[0].model for call in select_for_update_mock.call_args_list],
             "Daily quota checks must lock a PhoneToken row.",
         )
+        generic_lock_mock.assert_called_once_with()
         send_messages_mock.assert_called_once()
 
     @freeze_time(_TEST_DATE)

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -245,13 +245,11 @@ class TestPhoneToken(BaseTestCase):
     def test_send_token_logs_submission(self, send_messages_mock, logger_mock):
         token = self._create_token()
         logger_mock.info.assert_called_once_with(
-            "SMS token %s was submitted to the SMS backend for phone number %s, "
-            "user %s, organization %s, IP address %s.",
+            "SMS token %s was submitted to the SMS backend for user %s, "
+            "organization %s.",
             token.pk,
-            str(token.phone_number),
             token.user.pk,
             token.organization.pk,
-            token.ip,
         )
 
     @mock.patch("openwisp_radius.base.models.logger")
@@ -263,13 +261,11 @@ class TestPhoneToken(BaseTestCase):
         with self.assertRaisesMessage(RuntimeError, "SMS backend unavailable"):
             token.send_token()
         logger_mock.exception.assert_called_once_with(
-            "Failed to submit SMS token %s to the SMS backend for phone number %s, "
-            "user %s, organization %s, IP address %s.",
+            "Failed to submit SMS token %s to the SMS backend for user %s, "
+            "organization %s.",
             token.pk,
-            str(token.phone_number),
             token.user.pk,
             token.organization.pk,
-            token.ip,
         )
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
@@ -286,6 +282,21 @@ class TestPhoneToken(BaseTestCase):
             ValidationError, "This international mobile prefix is not allowed."
         ):
             token.send_token()
+        send_messages_mock.assert_not_called()
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_send_token_rechecks_phone_number_type(self, send_messages_mock):
+        self.default_org.radius_settings.allowed_mobile_prefixes = "+1"
+        self.default_org.radius_settings.full_clean()
+        self.default_org.radius_settings.save()
+        with mock.patch.object(app_settings, "ALLOW_FIXED_LINE_OR_MOBILE", True):
+            token = self._create_token(phone_number="+1 7795 106991")
+        send_messages_mock.reset_mock()
+        with mock.patch.object(app_settings, "ALLOW_FIXED_LINE_OR_MOBILE", False):
+            with self.assertRaisesMessage(
+                ValidationError, "Only mobile phone numbers are allowed."
+            ):
+                token.send_token()
         send_messages_mock.assert_not_called()
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -248,7 +248,7 @@ class TestPhoneToken(BaseTestCase):
             "SMS token %s was submitted to the SMS backend for phone number %s, "
             "user %s, organization %s.",
             token.pk,
-            f"{str(token.phone_number)[:-4]}****",
+            "+39******1808",
             token.user.pk,
             token.organization.pk,
         )
@@ -265,7 +265,7 @@ class TestPhoneToken(BaseTestCase):
             "Failed to submit SMS token %s to the SMS backend for phone number %s, "
             "user %s, organization %s.",
             token.pk,
-            f"{str(token.phone_number)[:-4]}****",
+            "+39******1808",
             token.user.pk,
             token.organization.pk,
         )

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -218,12 +218,75 @@ class TestPhoneToken(BaseTestCase):
         else:
             self.fail("ValidationError not raised")
 
+    def test_phone_token_rejects_disallowed_prefix(self):
+        self.default_org.radius_settings.allowed_mobile_prefixes = "+39"
+        self.default_org.radius_settings.full_clean()
+        self.default_org.radius_settings.save()
+        token = PhoneToken(
+            user=self._get_user_with_org(),
+            organization=self.default_org,
+            ip="127.0.0.1",
+            phone_number="+44 7795 106991",
+        )
+        with self.assertRaisesMessage(
+            ValidationError, "This international mobile prefix is not allowed."
+        ):
+            token.full_clean()
+
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
     def test_send_token_called_once(self, send_messages_mock):
         token = self._create_token()
         token.valid_until += timedelta(hours=1)  # change anything to save
         token.save()
         send_messages_mock.assert_called_once()
+
+    @mock.patch("openwisp_radius.base.models.logger")
+    @mock.patch("openwisp_radius.utils.SmsMessage.send", return_value=1)
+    def test_send_token_logs_submission(self, send_messages_mock, logger_mock):
+        token = self._create_token()
+        logger_mock.info.assert_called_once_with(
+            "SMS token %s was submitted to the SMS backend for phone number %s, "
+            "user %s, organization %s, IP address %s.",
+            token.pk,
+            str(token.phone_number),
+            token.user.pk,
+            token.organization.pk,
+            token.ip,
+        )
+
+    @mock.patch("openwisp_radius.base.models.logger")
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_send_token_logs_failure(self, send_messages_mock, logger_mock):
+        token = self._create_token()
+        logger_mock.reset_mock()
+        send_messages_mock.side_effect = RuntimeError("SMS backend unavailable")
+        with self.assertRaisesMessage(RuntimeError, "SMS backend unavailable"):
+            token.send_token()
+        logger_mock.exception.assert_called_once_with(
+            "Failed to submit SMS token %s to the SMS backend for phone number %s, "
+            "user %s, organization %s, IP address %s.",
+            token.pk,
+            str(token.phone_number),
+            token.user.pk,
+            token.organization.pk,
+            token.ip,
+        )
+
+    @mock.patch("openwisp_radius.utils.SmsMessage.send")
+    def test_send_token_rechecks_allowed_prefix(self, send_messages_mock):
+        self.default_org.radius_settings.allowed_mobile_prefixes = "+44"
+        self.default_org.radius_settings.full_clean()
+        self.default_org.radius_settings.save()
+        token = self._create_token(phone_number="+44 7795 106991")
+        send_messages_mock.reset_mock()
+        self.default_org.radius_settings.allowed_mobile_prefixes = "+39"
+        self.default_org.radius_settings.full_clean()
+        self.default_org.radius_settings.save()
+        with self.assertRaisesMessage(
+            ValidationError, "This international mobile prefix is not allowed."
+        ):
+            token.send_token()
+        send_messages_mock.assert_not_called()
 
     @mock.patch("openwisp_radius.utils.SmsMessage.send")
     @mock.patch("openwisp_radius.utils.SmsMessage.__init__", return_value=None)

--- a/openwisp_radius/tests/test_token.py
+++ b/openwisp_radius/tests/test_token.py
@@ -245,9 +245,10 @@ class TestPhoneToken(BaseTestCase):
     def test_send_token_logs_submission(self, send_messages_mock, logger_mock):
         token = self._create_token()
         logger_mock.info.assert_called_once_with(
-            "SMS token %s was submitted to the SMS backend for user %s, "
-            "organization %s.",
+            "SMS token %s was submitted to the SMS backend for phone number %s, "
+            "user %s, organization %s.",
             token.pk,
+            f"{str(token.phone_number)[:-4]}****",
             token.user.pk,
             token.organization.pk,
         )
@@ -260,10 +261,11 @@ class TestPhoneToken(BaseTestCase):
         send_messages_mock.side_effect = RuntimeError("SMS backend unavailable")
         with self.assertRaisesMessage(RuntimeError, "SMS backend unavailable"):
             token.send_token()
-        logger_mock.exception.assert_called_once_with(
-            "Failed to submit SMS token %s to the SMS backend for user %s, "
-            "organization %s.",
+        logger_mock.error.assert_called_once_with(
+            "Failed to submit SMS token %s to the SMS backend for phone number %s, "
+            "user %s, organization %s.",
             token.pk,
+            f"{str(token.phone_number)[:-4]}****",
             token.user.pk,
             token.organization.pk,
         )
@@ -279,7 +281,7 @@ class TestPhoneToken(BaseTestCase):
         self.default_org.radius_settings.full_clean()
         self.default_org.radius_settings.save()
         with self.assertRaisesMessage(
-            ValidationError, "This international mobile prefix is not allowed."
+            ValueError, "This international mobile prefix is not allowed."
         ):
             token.send_token()
         send_messages_mock.assert_not_called()
@@ -294,7 +296,7 @@ class TestPhoneToken(BaseTestCase):
         send_messages_mock.reset_mock()
         with mock.patch.object(app_settings, "ALLOW_FIXED_LINE_OR_MOBILE", False):
             with self.assertRaisesMessage(
-                ValidationError, "Only mobile phone numbers are allowed."
+                ValueError, "Only mobile phone numbers are allowed."
             ):
                 token.send_token()
         send_messages_mock.assert_not_called()

--- a/openwisp_radius/tests/test_utils.py
+++ b/openwisp_radius/tests/test_utils.py
@@ -4,12 +4,25 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 
-from ..utils import find_available_username, get_one_time_login_url, validate_csvfile
+from ..utils import (
+    find_available_username,
+    get_one_time_login_url,
+    mask_phone_number,
+    validate_csvfile,
+)
 from . import FileMixin
 from .mixins import BaseTestCase
 
 
 class TestUtils(FileMixin, BaseTestCase):
+    def test_mask_phone_number(self):
+        for phone_number, expected in (
+            ("+39 366 435 1808", "+39******1808"),
+            ("+1 202 555 1234", "+1******1234"),
+        ):
+            with self.subTest(phone_number=phone_number):
+                self.assertEqual(mask_phone_number(phone_number), expected)
+
     def test_find_available_username(self):
         User = get_user_model()
         User.objects.create(username="rohith", password="password")

--- a/openwisp_radius/utils.py
+++ b/openwisp_radius/utils.py
@@ -5,6 +5,7 @@ import os
 from datetime import timedelta
 from io import BytesIO, StringIO
 
+import phonenumbers
 import swapper
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -32,6 +33,20 @@ logger = logging.getLogger(__name__)
 
 def load_model(model):
     return swapper.load_model("openwisp_radius", model)
+
+
+def mask_phone_number(phone_number):
+    """Masks a phone number.
+
+    Returns only the international prefix, asterisks and the last 4 digits.
+    Used for logging.
+    """
+    number = phonenumbers.parse(str(phone_number))
+    country_code = f"+{number.country_code}"
+    national_number = str(number.national_number)
+    return (
+        f"{country_code}{'*' * max(len(national_number) - 4, 0)}{national_number[-4:]}"
+    )
 
 
 def get_model(apps, model_path):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I performed manual testing.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

- Enforced phone prefix and mobile-number validation at SMS token model and dispatch boundaries.
- Prevented caller-controlled forwarding headers from bypassing SMS IP limits.
- Added SMS submission audit logs without recording OTP values or backend credentials.

## Screenshot

N/A

[backport 1.2]
[backport 1.3]
